### PR TITLE
[Docs]Fix wrong links to docs of project in OpenMMLab

### DIFF
--- a/docs_zh-CN/conf.py
+++ b/docs_zh-CN/conf.py
@@ -108,12 +108,12 @@ html_theme_options = {
                 },
                 {
                     'name': 'MMClassification',
-                    'url': 'https://github.com/open-mmlab/mmclassification',
+                    'url':
+                    'https://mmclassification.readthedocs.io/zh_CN/latest/',
                 },
                 {
                     'name': 'MMDetection',
-                    'url':
-                    'https://mmclassification.readthedocs.io/zh_CN/latest/',
+                    'url': 'https://mmdetection.readthedocs.io/zh_CN/latest/',
                 },
                 {
                     'name': 'MMDetection3D',


### PR DESCRIPTION
# Modification

1. fix links in docs_zh-CN/conf.py
