### PR TITLE
[Enhancement] Try to create a symbolic link on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,8 +128,19 @@ def add_mim_extension():
 
             if mode == 'symlink':
                 src_relpath = osp.relpath(src_path, osp.dirname(tar_path))
-                os.symlink(src_relpath, tar_path)
-            elif mode == 'copy':
+                try:
+                    os.symlink(src_relpath, tar_path)
+                except OSError:
+                    # trying to create a symbolic link on windows may
+                    # raise an `OSError: [WinError 1314]` due to privilege
+                    mode = 'copy'
+                    warnings.warn(
+                        f'Failed to create a symbolic link for {src_relpath}, '
+                        f'and it will be copied to {tar_path}')
+                else:
+                    continue
+
+            if mode == 'copy':
                 if osp.isfile(src_path):
                     shutil.copyfile(src_path, tar_path)
                 elif osp.isdir(src_path):

--- a/setup.py
+++ b/setup.py
@@ -131,8 +131,9 @@ def add_mim_extension():
                 try:
                     os.symlink(src_relpath, tar_path)
                 except OSError:
-                    # trying to create a symbolic link on windows may
-                    # raise an `OSError: [WinError 1314]` due to privilege
+                    # Create a symbolic link on windows may raise an
+                    # `OSError: [WinError 1314]` due to privilege. If
+                    # error happens, the src file will be copied
                     mode = 'copy'
                     warnings.warn(
                         f'Failed to create a symbolic link for {src_relpath}, '

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ def add_mim_extension():
                 try:
                     os.symlink(src_relpath, tar_path)
                 except OSError:
-                    # Create a symbolic link on windows may raise an
+                    # Creating a symbolic link on windows may raise an
                     # `OSError: [WinError 1314]` due to privilege. If
                     # error happens, the src file will be copied
                     mode = 'copy'

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ def add_mim_extension():
                 except OSError:
                     # Creating a symbolic link on windows may raise an
                     # `OSError: [WinError 1314]` due to privilege. If
-                    # error happens, the src file will be copied
+                    # the error happens, the src file will be copied
                     mode = 'copy'
                     warnings.warn(
                         f'Failed to create a symbolic link for {src_relpath}, '


### PR DESCRIPTION
Related Issue: https://github.com/open-mmlab/mmdetection/issues/6480

Creating a symbolic link on windows may raise an `OSError: [WinError 1314]` due to privilege. If the error happens, the src file will be copied.
