### PR TITLE
[Feature] Add `scale_as_level` for multi-level flow loss

### DIFF
--- a/mmflow/models/losses/multilevel_epe.py
+++ b/mmflow/models/losses/multilevel_epe.py
@@ -79,6 +79,10 @@ class MultiLevelEPE(nn.Module):
             'upsample' is used for sparse flow map as no generic interpolation
             mode can resize a ground truth of sparse flow correctly.
             Default to 'downsample'.
+        scale_as_level (bool): Whether flow for each level is at its native
+            spatial resolution. If `'scale_as_level'` is True, the ground
+            truth is scaled at different levels, if it is False, the ground
+            truth will not be scaled. Default to False.
         reduction (str): the reduction to apply to the output:'none', 'mean',
             'sum'. 'none': no reduction will be applied and will return a
             full-size epe map, 'mean': the mean of the epe map is taken, 'sum':
@@ -99,6 +103,7 @@ class MultiLevelEPE(nn.Module):
                  flow_div: float = 20.,
                  max_flow: float = float('inf'),
                  resize_flow: str = 'downsample',
+                 scale_as_level: bool = False,
                  reduction: str = 'sum') -> None:
 
         super().__init__()
@@ -125,6 +130,9 @@ class MultiLevelEPE(nn.Module):
 
         assert resize_flow in ('downsample', 'upsample')
         self.resize_flow = resize_flow
+
+        assert isinstance(scale_as_level, bool)
+        self.scale_as_level = scale_as_level
 
         assert reduction in ('mean', 'sum')
         self.reduction = reduction
@@ -157,6 +165,7 @@ class MultiLevelEPE(nn.Module):
             flow_div=self.flow_div,
             max_flow=self.max_flow,
             resize_flow=self.resize_flow,
+            scale_as_level=self.scale_as_level,
             reduction=self.reduction,
             p=self.p,
             q=self.q,
@@ -166,7 +175,9 @@ class MultiLevelEPE(nn.Module):
     def __repr__(self) -> str:
 
         repr_str = self.__class__.__name__
-        repr_str += (f'(flow_div={self.flow_div}, '
+        repr_str += (f'(resize_flow={self.resize_flow}, '
+                     f'scale_as_level={self.scale_as_level}, '
+                     f'flow_div={self.flow_div}, '
                      f'weights={self.weights}, '
                      f'p={self.p}, '
                      f'q={self.q}, '

--- a/mmflow/models/losses/multilevel_flow_loss.py
+++ b/mmflow/models/losses/multilevel_flow_loss.py
@@ -77,7 +77,8 @@ def multi_level_flow_loss(loss_function,
 
     target_div = target / flow_div
 
-    h_org, w_org = target.shape[2:]
+    c_org, h_org, w_org = target.shape[1:]
+    assert c_org == 2, f'The channels ground truth must be 2, but got {c_org}'
 
     loss = 0
 

--- a/mmflow/models/losses/multilevel_flow_loss.py
+++ b/mmflow/models/losses/multilevel_flow_loss.py
@@ -20,6 +20,7 @@ def multi_level_flow_loss(loss_function,
                           max_flow: float = float('inf'),
                           resize_flow: str = 'downsample',
                           reduction: str = 'sum',
+                          scale_as_level: bool = False,
                           **kwargs) -> torch.Tensor:
     """Multi-level endpoint error loss function.
 
@@ -45,6 +46,17 @@ def multi_level_flow_loss(loss_function,
             full-size epe map, 'mean': the mean of the epe map is taken, 'sum':
             the epe map will be summed but averaged by batch_size.
             Default: 'sum'.
+        resize_flow (str): mode for reszing flow: 'downsample' and 'upsample',
+            as multi-level predicted outputs don't match the ground truth.
+            If set to 'downsample', it will downsample the ground truth, and
+            if set to 'upsample' it will upsample the predicted flow, and
+            'upsample' is used for sparse flow map as no generic interpolation
+            mode can resize a ground truth of sparse flow correctly.
+            Default to 'downsample'.
+        scale_as_level (bool): Whether flow for each level is at its native
+            spatial resolution. If `'scale_as_level'` is True, the ground
+            truth is scaled at different levels, if it is False, the ground
+            truth will not be scaled. Default to False.
         kwargs: arguments for loss_function.
 
     Returns:
@@ -65,6 +77,8 @@ def multi_level_flow_loss(loss_function,
 
     target_div = target / flow_div
 
+    h_org, w_org = target.shape[2:]
+
     loss = 0
 
     for level in weights.keys():
@@ -76,6 +90,10 @@ def multi_level_flow_loss(loss_function,
         num_preds = len(cur_pred)
 
         b, _, h, w = cur_pred[0].shape
+
+        scale_factor = torch.Tensor([
+            float(w / w_org), float(h / h_org)
+        ]).to(target) if scale_as_level else torch.Tensor([1., 1.]).to(target)
 
         cur_weight = weights.get(level)
 
@@ -103,6 +121,9 @@ def multi_level_flow_loss(loss_function,
                     size=cur_target.shape[2:],
                     mode='bilinear',
                     align_corners=False)
+
+            cur_target = torch.einsum('b c h w, c -> b c h w', cur_target,
+                                      scale_factor)
 
             loss_map += loss_function(i_pred, cur_target, **kwargs) * cur_valid
 


### PR DESCRIPTION
# Motivation 

Optical flow models always predict values of flow as ground truth resolution, even though the resolution is different at each level. This `scale_as_level` works for deciding whether to scale flow for each level at its native spatial resolution.

# Modification

1. Add `scale_as_level` in `multi_level_flow_loss`
2. Add `scale_as_level` in `MultiLevelEPE`
3. Add `scale_as_level` in `class MultiLevelCharbonnierLoss`
4. Revise UT for losses function.