### PR TITLE
[Enhancement] Add presistent_workers=True in val_dataloader

### DIFF
--- a/configs/_base_/datasets/chairssdhom_384x448.py
+++ b/configs/_base_/datasets/chairssdhom_384x448.py
@@ -70,7 +70,11 @@ data = dict(
         workers_per_gpu=2,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=chairssdhom_train,
     val=dict(

--- a/configs/_base_/datasets/flyingchairs_320x448.py
+++ b/configs/_base_/datasets/flyingchairs_320x448.py
@@ -73,7 +73,11 @@ data = dict(
         workers_per_gpu=2,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=flyingchairs_train,
     val=dict(

--- a/configs/_base_/datasets/flyingchairs_384x448.py
+++ b/configs/_base_/datasets/flyingchairs_384x448.py
@@ -73,7 +73,11 @@ data = dict(
         workers_per_gpu=2,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=flyingchairs_train,
     val=dict(

--- a/configs/_base_/datasets/flyingchairs_raft_368x496.py
+++ b/configs/_base_/datasets/flyingchairs_raft_368x496.py
@@ -67,7 +67,11 @@ data = dict(
         drop_last=True,
         shuffle=False,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=flyingchairs_train,
     val=dict(

--- a/configs/_base_/datasets/flyingchairsocc_bi_occ_384x448.py
+++ b/configs/_base_/datasets/flyingchairsocc_bi_occ_384x448.py
@@ -81,7 +81,11 @@ data = dict(
         workers_per_gpu=2,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=flyingchairsocc_train,
     val=flyingchairsocc_test_val,

--- a/configs/_base_/datasets/flyingthings3d_raft_400x720.py
+++ b/configs/_base_/datasets/flyingthings3d_raft_400x720.py
@@ -88,7 +88,11 @@ data = dict(
         workers_per_gpu=2,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=[train_dataset_cleanpass, train_dataset_finalpass],
     val=dict(

--- a/configs/_base_/datasets/flyingthings3d_subset_384x768.py
+++ b/configs/_base_/datasets/flyingthings3d_subset_384x768.py
@@ -89,7 +89,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=flyingthings3d_subset_train,
     val=dict(

--- a/configs/_base_/datasets/flyingthings3d_subset_bi_with_occ_384x768.py
+++ b/configs/_base_/datasets/flyingthings3d_subset_bi_with_occ_384x768.py
@@ -92,7 +92,11 @@ data = dict(
         workers_per_gpu=2,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=flyingthings3d_subset_bidirection_train,
     val=dict(

--- a/configs/_base_/datasets/flyingthings3d_subset_chairssdhom_384x448.py
+++ b/configs/_base_/datasets/flyingthings3d_subset_chairssdhom_384x448.py
@@ -97,7 +97,11 @@ data = dict(
         shuffle=False,
         sample_ratio=(0.25, 0.75),
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[flyingthings3d_subset_train, chairssdHom_train],
     val=dict(

--- a/configs/_base_/datasets/kitti2012_kitti2015_320x896.py
+++ b/configs/_base_/datasets/kitti2012_kitti2015_320x896.py
@@ -91,7 +91,11 @@ data = dict(
         drop_last=True,
         shuffle=False,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[kitti2015_train, kitti2012_train],
     val=dict(

--- a/configs/_base_/datasets/kitti2012_kitti2015_irr_320x896.py
+++ b/configs/_base_/datasets/kitti2012_kitti2015_irr_320x896.py
@@ -92,7 +92,11 @@ data = dict(
         drop_last=True,
         shuffle=False,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[kitti2015_train, kitti2012_train],
     val=dict(

--- a/configs/_base_/datasets/sintel_384x768.py
+++ b/configs/_base_/datasets/sintel_384x768.py
@@ -97,7 +97,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[sintel_clean_train, sintel_final_train],
     val=dict(

--- a/configs/_base_/datasets/sintel_cleanx100_sintel_fianlx100_flyingthings3d_raft_368x768.py
+++ b/configs/_base_/datasets/sintel_cleanx100_sintel_fianlx100_flyingthings3d_raft_368x768.py
@@ -135,7 +135,11 @@ data = dict(
         drop_last=True,
         shuffle=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=2,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=2, shuffle=False),
     train=[
         sintel_clean_train_x100, sintel_final_train_x100,

--- a/configs/_base_/datasets/sintel_cleanx100_sintel_fianlx100_kitti2015x200_hd1kx5_flyingthings3d_raft_384x768.py
+++ b/configs/_base_/datasets/sintel_cleanx100_sintel_fianlx100_kitti2015x200_hd1kx5_flyingthings3d_raft_384x768.py
@@ -216,7 +216,11 @@ data = dict(
         drop_last=True,
         shuffle=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[
         sintel_clean_train_x100, sintel_final_train_x100, kitti_train_x200,

--- a/configs/_base_/datasets/sintel_final_384x768.py
+++ b/configs/_base_/datasets/sintel_final_384x768.py
@@ -87,7 +87,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[sintel_final_train],
     val=dict(

--- a/configs/_base_/datasets/sintel_final_irr_with_occ_384x768.py
+++ b/configs/_base_/datasets/sintel_final_irr_with_occ_384x768.py
@@ -88,7 +88,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=sintel_final_train,
     val=dict(

--- a/configs/_base_/datasets/sintel_final_pwcnet_384x768.py
+++ b/configs/_base_/datasets/sintel_final_pwcnet_384x768.py
@@ -89,7 +89,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[sintel_final_train],
     val=dict(

--- a/configs/_base_/datasets/sintel_irr_with_occ_384x768.py
+++ b/configs/_base_/datasets/sintel_irr_with_occ_384x768.py
@@ -95,7 +95,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[sintel_clean_train, sintel_final_train],
     val=dict(

--- a/configs/_base_/datasets/sintel_kitti2015_hd1k_320x768.py
+++ b/configs/_base_/datasets/sintel_kitti2015_hd1k_320x768.py
@@ -180,7 +180,11 @@ data = dict(
         drop_last=True,
         sample_ratio=(0.5, 0.25, 0.25),
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[[sintel_clean_train, sintel_final_train], kitti2015_train,
            hd1k_train],

--- a/configs/_base_/datasets/sintel_kitti2015_hd1k_maskflownet_320x768.py
+++ b/configs/_base_/datasets/sintel_kitti2015_hd1k_maskflownet_320x768.py
@@ -199,7 +199,11 @@ data = dict(
         drop_last=True,
         sample_ratio=(0.5, 0.25, 0.25),
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[[sintel_clean_train, sintel_final_train], kitti2015_train,
            hd1k_train],

--- a/configs/_base_/datasets/sintel_kitti_liteflownet2_320x768.py
+++ b/configs/_base_/datasets/sintel_kitti_liteflownet2_320x768.py
@@ -175,7 +175,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[
         sintel_clean_train, sintel_final_train, kitti2015_train,

--- a/configs/_base_/datasets/sintel_liteflownet_384x768.py
+++ b/configs/_base_/datasets/sintel_liteflownet_384x768.py
@@ -93,7 +93,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[sintel_clean_train, sintel_final_train],
     val=dict(

--- a/configs/_base_/datasets/sintel_pwcnet_384x768.py
+++ b/configs/_base_/datasets/sintel_pwcnet_384x768.py
@@ -96,7 +96,11 @@ data = dict(
         workers_per_gpu=5,
         drop_last=True,
         persistent_workers=True),
-    val_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
+    val_dataloader=dict(
+        samples_per_gpu=1,
+        workers_per_gpu=5,
+        shuffle=False,
+        persistent_workers=True),
     test_dataloader=dict(samples_per_gpu=1, workers_per_gpu=5, shuffle=False),
     train=[sintel_clean_train, sintel_final_train],
     val=dict(


### PR DESCRIPTION
# Motivation

`presistent_workers=True` in val_dataloader will speed up evaluation during training and not affect iter training time.