### PR TITLE
[Fix] Resized input image must be dividable by 2^6

### DIFF
--- a/configs/_base_/datasets/flyingthings3d_subset_chairssdhom_384x448.py
+++ b/configs/_base_/datasets/flyingthings3d_subset_chairssdhom_384x448.py
@@ -48,7 +48,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(

--- a/configs/_base_/datasets/sintel_384x768.py
+++ b/configs/_base_/datasets/sintel_384x768.py
@@ -50,7 +50,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(

--- a/configs/_base_/datasets/sintel_final_384x768.py
+++ b/configs/_base_/datasets/sintel_final_384x768.py
@@ -49,7 +49,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(

--- a/configs/_base_/datasets/sintel_final_irr_with_occ_384x768.py
+++ b/configs/_base_/datasets/sintel_final_irr_with_occ_384x768.py
@@ -48,7 +48,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(

--- a/configs/_base_/datasets/sintel_final_pwcnet_384x768.py
+++ b/configs/_base_/datasets/sintel_final_pwcnet_384x768.py
@@ -49,7 +49,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(

--- a/configs/_base_/datasets/sintel_irr_with_occ_384x768.py
+++ b/configs/_base_/datasets/sintel_irr_with_occ_384x768.py
@@ -48,7 +48,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(

--- a/configs/_base_/datasets/sintel_pwcnet_384x768.py
+++ b/configs/_base_/datasets/sintel_pwcnet_384x768.py
@@ -49,7 +49,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(


### PR DESCRIPTION
# Motivation
1. For PWCNet, FlowNet and IRR-PWC, the input image must be dividable by 2^6
2. fix #64 