### PR TITLE
Deprecate the support for "python setup.py test"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,8 +176,6 @@ if __name__ == '__main__':
         author='MMFlow Contributors',
         author_email='openmmlab@gmail.com',
         license='Apache License 2.0',
-        setup_requires=parse_requirements('requirements/build.txt'),
-        tests_require=parse_requirements('requirements/tests.txt'),
         install_requires=parse_requirements('requirements/runtime.txt'),
         extras_require={
             'all': parse_requirements('requirements.txt'),


### PR DESCRIPTION
refer to https://github.com/open-mmlab/mmcv/pull/1637