### PR TITLE
[Enhancement] Upgrade isort in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,8 @@ repos:
     rev: 3.8.3
     hooks:
       - id: flake8
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [isort]
 line_length = 79
 multi_line_output = 0
-known_standard_library = setuptools
+extra_standard_library = setuptools
 known_first_party = mmflow
 known_third_party = PIL,cv2,matplotlib,mmcv,numpy,pytest,pytorch_sphinx_theme,requests,torch,torchvision,ts
 no_lines_before = STDLIB,LOCALFOLDER


### PR DESCRIPTION
## Modification

1. Remove `seed-isort-config` in pre-commit hook
2. Upgrade `isort` to v5.10.1 (latest version)
3. Replace `known_standard_library` with `extra_standard_library`