### PR TITLE
[Enhancement] Update the installation of MMCV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,16 +29,10 @@ jobs:
             torchvision: 0.6.1
           - torch: 1.7.1
             torch_version: torch1.7
-            torchvision: 0.8.1
-          - torch: 1.8.0
-            torch_version: torch1.8
-            torchvision: 0.9.0
+            torchvision: 0.8.2
           - torch: 1.9.0
             torch_version: torch1.9
             torchvision: 0.10.0
-          - torch: 1.8.0
-            torch_version: torch1.8
-            torchvision: 0.9.0
             python-version: 3.9
           - torch: 1.9.0
             torch_version: torch1.9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.5.1, 1.7.1, 1.8.0, 1.9.0]
+        torch: [1.5.1, 1.7.1, 1.9.0]
         include:
           - torch: 1.5.1
             torch_version: torch1.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV
         run: |
-          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch_version}}/index.html
+          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/${{matrix.torch_version}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
         run: pip install -r requirements/tests.txt -r requirements/optional.txt
@@ -110,7 +110,7 @@ jobs:
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV
         run: |
-          python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/torch${{matrix.torch_version}}/index.html
+          python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.torch_version}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
         run: python -m pip install -r requirements/tests.txt -r requirements/optional.txt
@@ -160,7 +160,7 @@ jobs:
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV
         run: |
-          python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch${{matrix.torch_version}}/index.html
+          python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/${{matrix.torch_version}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
         run: python -m pip install -r requirements/tests.txt -r requirements/optional.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
           - torch: 1.9.0
             torch_version: torch1.9
             torchvision: 0.10.0
-            python-version: 3.9
           - torch: 1.9.0
             torch_version: torch1.9
             torchvision: 0.10.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,23 +22,30 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.6.0, 1.7.0, 1.8.0, 1.9.0]
+        torch: [1.5.1, 1.7.1, 1.8.0, 1.9.0]
         include:
-          - torch: 1.6.0
-            torchvision: 0.7.0
-          - torch: 1.7.0
+          - torch: 1.5.1
+            torch_version: torch1.5
+            torchvision: 0.6.1
+          - torch: 1.7.1
+            torch_version: torch1.7
             torchvision: 0.8.1
           - torch: 1.8.0
+            torch_version: torch1.8
             torchvision: 0.9.0
           - torch: 1.9.0
+            torch_version: torch1.9
             torchvision: 0.10.0
           - torch: 1.8.0
+            torch_version: torch1.8
             torchvision: 0.9.0
             python-version: 3.9
           - torch: 1.9.0
+            torch_version: torch1.9
             torchvision: 0.10.0
             python-version: 3.8
           - torch: 1.9.0
+            torch_version: torch1.9
             torchvision: 0.10.0
             python-version: 3.9
     steps:
@@ -51,7 +58,7 @@ jobs:
         run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install MMCV
         run: |
-          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch}}/index.html
+          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch_version}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
         run: pip install -r requirements/tests.txt -r requirements/optional.txt
@@ -75,24 +82,24 @@ jobs:
         torch: [1.6.0+cu101, 1.7.0+cu101, 1.8.0+cu101]
         include:
           - torch: 1.6.0+cu101
-            torch_version: 1.6.0
+            torch_version: torch1.6
             torchvision: 0.7.0+cu101
           - torch: 1.7.0+cu101
-            torch_version: 1.7.0
+            torch_version: torch1.7
             torchvision: 0.8.1+cu101
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: torch1.8
             torchvision: 0.9.0+cu101
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: torch1.8
             torchvision: 0.9.0+cu101
             python-version: 3.6
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: torch1.8
             torchvision: 0.9.0+cu101
             python-version: 3.8
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: torch1.8
             torchvision: 0.9.0+cu101
             python-version: 3.9
     steps:
@@ -135,14 +142,14 @@ jobs:
         torch: [1.9.0+cu102]
         include:
           - torch: 1.9.0+cu102
-            torch_version: 1.9.0
+            torch_version: torch1.9
             torchvision: 0.10.0+cu102
           - torch: 1.9.0+cu102
-            torch_version: 1.9.0
+            torch_version: torch1.9
             torchvision: 0.10.0+cu102
             python-version: 3.8
           - torch: 1.9.0+cu102
-            torch_version: 1.9.0
+            torch_version: torch1.9
             torchvision: 0.10.0+cu102
             python-version: 3.9
     steps:

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -57,10 +57,13 @@ c. Install MMCV, we recommend you to install the pre-built mmcv as below.
 pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/{cu_version}/{torch_version}/index.html
 ```
 
-Please replace ``{cu_version}`` and ``{torch_version}`` in the url to your desired one. For example, to install the latest ``mmcv-full`` with ``CUDA 10.2`` and ``PyTorch 1.10.0``, use the following command:
+Please replace ``{cu_version}`` and ``{torch_version}`` in the url to your desired one. mmcv-full is only compiled on
+PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1,
+you can install mmcv-full compiled with PyTorch 1.x.0 and it usually works well.
+For example, to install the latest ``mmcv-full`` with ``CUDA 10.2`` and ``PyTorch 1.10.0``, use the following command:
 
 ```shell
-pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.10.0/index.html
+pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.10/index.html
 ```
 
 See [here](https://github.com/open-mmlab/mmcv#installation) for different versions of MMCV compatible to different PyTorch and CUDA versions.
@@ -76,6 +79,7 @@ cd ..
 ```
 
 **Important:** You need to run `pip uninstall mmcv` first if you have mmcv installed. If `mmcv` and `mmcv-full` are both installed, there will be `ModuleNotFoundError`.
+
 ## Install MMFlow
 
 a. Clone the MMFlow repository.


### PR DESCRIPTION
# Motivation

mmcv-full is only compiled on PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1, you can install mmcv-full compiled with PyTorch 1.x.0 and it usually works well.
Refer to https://github.com/open-mmlab/mmtracking/pull/409

# Modificatin

modify build.yml
modify install.md
