### PR TITLE
[Fix] The config and weights are not corresponding in the metafile.yml

### DIFF
--- a/configs/pwcnet/metafile.yml
+++ b/configs/pwcnet/metafile.yml
@@ -16,7 +16,7 @@ Collections:
 Models:
   - Name: pwcnet_8x1_slong_flyingchairs_384x448
     In Collection: PWC-Net
-    Config: configs/pwcnet/pwcnet_8x1_sfine_flyingthings3d_subset_384x768.py
+    Config: configs/pwcnet/pwcnet_8x1_slong_flyingchairs_384x448.py
     Metadata:
       Training Data: FlyingChairs
     Results:


### PR DESCRIPTION
# Motivation

The config and weights are not corresponding in the metafile.yml

# Modification

Revise the metafile from pwcnet