### PR TITLE
[Docs] Configure Myst-parser to parse anchor tag

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -37,12 +37,8 @@ def get_version():
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode',
-    'myst_parser',
-    'sphinx.ext.autosectionlabel',
-    'sphinx_copybutton',
+    'sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinx.ext.viewcode',
+    'sphinx_markdown_tables', 'sphinx_copybutton', 'myst_parser'
 ]
 
 autodoc_mock_imports = ['matplotlib', 'mmflow.version', 'mmcv.ops']
@@ -78,14 +74,35 @@ html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
 # documentation.
 #
 html_theme_options = {
+    'logo_url':
+    'https://mmflow.readthedocs.io/en/latest/',
     'menu': [
+        {
+            'name':
+            'Tutorial',
+            'url':
+            'https://github.com/open-mmlab/mmflow/blob/master/'
+            'demo/mmflow_Tutorial.ipynb'
+        },
         {
             'name': 'GitHub',
             'url': 'https://github.com/open-mmlab/mmflow'
         },
+        {
+            'name':
+            'Upstream',
+            'children': [
+                {
+                    'name': 'MMCV',
+                    'url': 'https://github.com/open-mmlab/mmcv',
+                    'description': 'Foundational library for computer vision'
+                },
+            ]
+        },
     ],
     # Specify the language of shared menu
-    'menu_lang': 'en',
+    'menu_lang':
+    'en'
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -94,7 +111,8 @@ html_theme_options = {
 html_static_path = ['_static']
 html_css_files = ['css/readthedocs.css']
 
-# -- Extension configuration -------------------------------------------------
-# Ignore >>> when copying code
-copybutton_prompt_text = r'>>> |\.\.\. '
-copybutton_prompt_is_regexp = True
+# Enable ::: for my_st
+myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 3
+
+language = 'en'


### PR DESCRIPTION
By default, myst-parser did not parse links to anchor tags in markdown files, making these hyperlinks become raw texts in docs. This PR updates myst's configuration to enable this feature.

related PR https://github.com/open-mmlab/mmocr/pull/1012