### PR TITLE
[Fix] H and W input images must be divisible by 2**6

### DIFF
--- a/configs/_base_/datasets/sintel_kitti2015_hd1k_320x768.py
+++ b/configs/_base_/datasets/sintel_kitti2015_hd1k_320x768.py
@@ -47,7 +47,7 @@ sintel_train_pipeline = [
 sintel_test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='InputResize', exponent=4),
+    dict(type='InputResize', exponent=6),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='TestFormatBundle'),
     dict(


### PR DESCRIPTION
Fix https://github.com/open-mmlab/mmflow/issues/135