### PR TITLE
[Feature] Add config and pre-trained model for flownet2 on FlyingChairs

### DIFF
--- a/configs/flownet2/README.md
+++ b/configs/flownet2/README.md
@@ -63,7 +63,7 @@ computation at up to 140fps with accuracy matching the original FlowNet.
             <th>-</th>
             <th>-</th>
             <th><a href='https://download.openmmlab.com/mmflow/flownet2/flownet2cs_8x1_slong_flyingchairs_384x448.log.json'>log</a></th>
-            <th><a href='https://download.openmmlab.com/mmflow/flownet2/'>Config</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/flownet2/flownet2cs_8x1_slong_flyingchairs_384x448.py'>Config</a></th>
             <th><a href='https://download.openmmlab.com/mmflow/flownet2/flownet2cs_8x1_slong_flyingchairs_384x448.pth'>Model</a></th>
         </tr>
         <tr>
@@ -120,8 +120,21 @@ computation at up to 140fps with accuracy matching the original FlowNet.
         </tr>
         <tr>
             <th>FlowNet2</th>
+            <th>FlyingChairs</th>
+            <th>1.15</th>
+            <th>-</th>
+            <th>-</th>
+            <th>-</th>
+            <th>-</th>
+            <th>-</th>
+            <th><a href='https://download.openmmlab.com/mmflow/flownet2/flownet2_8x1_slong_flyingchairs_384x448_20220625_212801-88d61800.log.json'>log</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/flownet2/flownet2_8x1_slong_flyingchairs_384x448_20220625_212801-88d61800.py'>Config</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/flownet2/flownet2_8x1_slong_flyingchairs_384x448_20220625_212801-88d61800.pth'>Model</a></th>
+        </tr>
+        <tr>
+            <th>FlowNet2</th>
             <th>FlyingThing3d subset</th>
-            <th></th>
+            <th>-</th>
             <th>1.78</th>
             <th>3.31</th>
             <th>3.02</th>

--- a/configs/flownet2/flownet2_8x1_slong_flyingchairs_384x448.py
+++ b/configs/flownet2/flownet2_8x1_slong_flyingchairs_384x448.py
@@ -1,0 +1,5 @@
+_base_ = [
+    '../_base_/models/flownet2/flownet2.py',
+    '../_base_/datasets/flyingchairs_384x448.py',
+    '../_base_/schedules/schedule_s_long.py', '../_base_/default_runtime.py'
+]

--- a/configs/flownet2/metafile.yml
+++ b/configs/flownet2/metafile.yml
@@ -146,3 +146,15 @@ Models:
           EPE: 8.02
           Fl-all: 25.18%
     Weights: https://download.openmmlab.com/mmflow/flownet2/flownet2_8x1_sfine_flyingthings3d_subset_384x768.pth
+
+  - Name: flownet2_8x1_slong_flyingchairs_384x448
+    In Collection: FlowNet2
+    Config: configs/flownet2/flownet2_8x1_slong_flyingchairs_384x448
+    Metadata:
+      Training Data: FlyingChairs
+    Results:
+      - Task: Optical flow estimation
+        Dataset: FlyingChairs
+        Metrics:
+          EPE: 1.15
+    Weights: https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmflow/flownet2/flownet2_8x1_slong_flyingchairs_384x448_20220625_212801-88d61800.pth


### PR DESCRIPTION
## Motivation
Add config and pre-trained model for flownet2 on FlyingChairs.

## Modification
1. Add configs/flownet2/fflownet2_8x1_slong_flyingchairs_384x448.py
2. Fix configs/flownet2/metafile.yml
3. Fix configs/flownet2/REDAME.md
