### PR TITLE
[Feature] Add flow1d attention

### DIFF
--- a/mmflow/models/decoders/raft_decoder.py
+++ b/mmflow/models/decoders/raft_decoder.py
@@ -382,7 +382,7 @@ class RAFTDecoder(BaseDecoder):
 
         Args:
             flow (Tensor): The optical flow with the shape [N, 2, H/8, W/8].
-            mask (Tensor, optional): The leanable mask with shape
+            mask (Tensor, optional): The learnable mask with shape
                 [N, grid_size x scale x scale, H/8, H/8].
 
         Returns:

--- a/mmflow/models/utils/attention.py
+++ b/mmflow/models/utils/attention.py
@@ -34,10 +34,11 @@ class AttentionLayer(BaseModule):
 
         Args:
             feature1 (Tensor): The input feature1.
-            feature1 (Tensor): The input feature1.
+            feature2 (Tensor): The input feature2.
             position (Tensor): position encoding.
             value (Tensor): attention value.
         Returns:
+
             out (Tensor): attention layer output
             attention (Tensor): attention of key and query
         """
@@ -46,31 +47,30 @@ class AttentionLayer(BaseModule):
         query = feature1 + position if position is not None else feature1
         query = self.query_conv(query)
 
-        key = feature2 + position if position is not None else feature1
+        key = feature2 + position if position is not None else feature2
         key = self.key_conv(key)
 
         value = feature2 if value is None else value
         scale_factor = c**0.5
 
         if self.y_attention:
-            # multiple on H direction
-            query = query.permute(0, 3, 2, 1)  # [B, W, H, C]
-            key = key.permute(0, 3, 1, 2)  # [B, W, C, H]
-            value = value.permute(0, 3, 2, 1)  # [B, W, H, C]
+            # multiple on H direction, feature shape is [B, W, H, C]
+            query = query.permute(0, 3, 2, 1)
+            key = key.permute(0, 3, 1, 2)
+            value = value.permute(0, 3, 2, 1)
         else:  # x attention
-            # multiple on W direction
-            query = query.permute(0, 2, 3, 1)  # [B, H, W, C]
-            key = key.permute(0, 2, 1, 3)  # [B, H, C, W]
-            value = value.permute(0, 2, 3, 1)  # [B, H, W, C]
+            # multiple on W direction, feature shape is [B, W, H, C]
+            query = query.permute(0, 2, 3, 1)
+            key = key.permute(0, 2, 1, 3)
+            value = value.permute(0, 2, 3, 1)
 
-        scores = torch.matmul(
-            query, key) / scale_factor  # [B, W, H, H] or  [B, H, W, W]
+        # the shape of attention is [B, W, H, H] or  [B, H, W, W]
+        scores = torch.matmul(query, key) / scale_factor
+        attention = torch.softmax(scores, dim=-1)
 
-        attention = torch.softmax(
-            scores, dim=-1)  # [B, W, H, H] or  [B, H, W, W]
+        out = torch.matmul(attention, value)
 
-        out = torch.matmul(attention, value)  # [B, W, H, H] or  [B, H, W, W]
-
+        # the shape of output is [B, C, H, W]
         if self.y_attention:
             out = out.permute(0, 3, 2, 1).contiguous()  # [B, C, H, W]
         else:
@@ -95,12 +95,6 @@ class Attention1D(BaseModule):
 
         self.self_attn = AttentionLayer(in_channels, not y_attention)
         self.cross_attn = AttentionLayer(in_channels, y_attention)
-        self.query_conv = nn.Conv2d(in_channels, in_channels, 1)
-        self.key_conv = nn.Conv2d(in_channels, in_channels, 1)
-
-        for p in self.parameters():
-            if p.dim() > 1:
-                nn.init.xavier_uniform_(p)
 
     def forward(self, feature1, feature2, position, value):
         """Forward function for Attention1D.
@@ -110,6 +104,7 @@ class Attention1D(BaseModule):
             feature2 (Tensor): The input feature2.
             position (Tensor): position encoding.
             value (Tensor): attention value.
+
         Returns:
             out (Tensor): cross attention output
             attention (Tensor):  cross attention of key and query

--- a/mmflow/models/utils/attention.py
+++ b/mmflow/models/utils/attention.py
@@ -1,0 +1,97 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+
+import torch
+from mmcv.runner import BaseModule
+from torch import nn
+
+
+class Attention1D(BaseModule):
+    """Cross-Attention on x or y direction, without multi-head and dropout
+    support for faster speed First compute y or x direction self attention,
+    then compute x or y direction cross attention.
+
+    Args:
+        in_channels (int): Number of input channels.
+        y_attention (bool): Whether y axis's attention or not
+        double_cross_attention (bool): Whether double cross attention or not
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        y_attention: bool = False,
+        double_cross_attention: bool = False,
+    ):
+        super(Attention1D, self).__init__()
+        self.y_attention = y_attention
+        self.double_cross_attention = double_cross_attention
+
+        # do self attention first
+        if double_cross_attention:
+            self.self_attn = copy.deepcopy(
+                Attention1D(
+                    in_channels,
+                    y_attention=not y_attention,
+                ))
+
+        self.query_conv = nn.Conv2d(in_channels, in_channels, 1)
+        self.key_conv = nn.Conv2d(in_channels, in_channels, 1)
+
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(self, feature1, feature2, position, value):
+        """Forward function for Attention1D.
+        Key: feature2 + position
+        Value: feature2
+        Query: self attention feature1 + position
+
+                Args:
+                    feature1 (Tensor): The input feature1.
+                    feature2 (Tensor): The input feature2.
+                    position (Tensor): position encoding.
+                    value (Tensor): attention value.
+                Returns:
+
+                """
+        b, c, h, w = feature1.size()
+
+        if self.double_cross_attention:
+            feature1 = self.self_attn(feature1, feature1, position, value)[0]
+
+        query = feature1 + position if position is not None else feature1
+        query = self.query_conv(query)
+
+        key = feature2 + position if position is not None else feature2
+        key = self.key_conv(key)
+
+        value = feature2 if value is None else value
+        scale_factor = c**0.5
+
+        if self.y_attention:
+            # multiple on H direction
+            query = query.permute(0, 3, 2, 1)  # [B, W, H, C]
+            key = key.permute(0, 3, 1, 2)  # [B, W, C, H]
+            value = value.permute(0, 3, 2, 1)  # [B, W, H, C]
+        else:  # x attention
+            # multiple on W direction
+            query = query.permute(0, 2, 3, 1)  # [B, H, W, C]
+            key = key.permute(0, 2, 1, 3)  # [B, H, C, W]
+            value = value.permute(0, 2, 3, 1)  # [B, H, W, C]
+
+        scores = torch.matmul(
+            query, key) / scale_factor  # [B, W, H, H] or  [B, H, W, W]
+
+        attention = torch.softmax(
+            scores, dim=-1)  # [B, W, H, H] or  [B, H, W, W]
+
+        out = torch.matmul(attention, value)  # [B, W, H, H] or  [B, H, W, W]
+
+        if self.y_attention:
+            out = out.permute(0, 3, 2, 1).contiguous()  # [B, C, H, W]
+        else:
+            out = out.permute(0, 3, 1, 2).contiguous()  # [B, C, H, W]
+
+        return out, attention

--- a/mmflow/models/utils/attention.py
+++ b/mmflow/models/utils/attention.py
@@ -30,10 +30,10 @@ class AttentionLayer(BaseModule):
                 nn.init.xavier_uniform_(p)
 
     def forward(self, feature1, position, value):
-        """Forward function for Attention1D.
-        Key: feature2 + position
-        Value: feature2
-        Query: self attention feature1 + position
+        """Forward function for AttentionLayer.
+        Key: feature1 + position
+        Value: feature1
+        Query: feature1 + position
 
                 Args:
                     feature1 (Tensor): The input feature1.

--- a/mmflow/models/utils/attention.py
+++ b/mmflow/models/utils/attention.py
@@ -11,15 +11,11 @@ class AttentionLayer(BaseModule):
 
     Args:
         in_channels (int): Number of input channels.
-        y_attention (bool): Whether y axis's attention or not
+        y_attention (bool): Whether calculate y axis's attention or not.
     """
 
-    def __init__(
-        self,
-        in_channels: int,
-        y_attention: bool = False,
-    ):
-        super(AttentionLayer, self).__init__()
+    def __init__(self, in_channels: int, y_attention: bool = False):
+        super().__init__()
         self.y_attention = y_attention
 
         self.query_conv = nn.Conv2d(in_channels, in_channels, 1)
@@ -29,28 +25,31 @@ class AttentionLayer(BaseModule):
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
 
-    def forward(self, feature1, position, value):
+    def forward(self, feature1, feature2, position, value):
         """Forward function for AttentionLayer.
-        Key: feature1 + position
-        Value: feature1
+
+        Key: feature2 + position
+        Value: feature2
         Query: feature1 + position
 
-                Args:
-                    feature1 (Tensor): The input feature1.
-                    position (Tensor): position encoding.
-                    value (Tensor): attention value.
-                Returns:
-
-                """
+        Args:
+            feature1 (Tensor): The input feature1.
+            feature1 (Tensor): The input feature1.
+            position (Tensor): position encoding.
+            value (Tensor): attention value.
+        Returns:
+            out (Tensor): attention layer output
+            attention (Tensor): attention of key and query
+        """
         b, c, h, w = feature1.size()
 
         query = feature1 + position if position is not None else feature1
         query = self.query_conv(query)
 
-        key = feature1 + position if position is not None else feature1
+        key = feature2 + position if position is not None else feature1
         key = self.key_conv(key)
 
-        value = feature1 if value is None else value
+        value = feature2 if value is None else value
         scale_factor = c**0.5
 
         if self.y_attention:
@@ -88,19 +87,14 @@ class Attention1D(BaseModule):
     Args:
         in_channels (int): Number of input channels.
         y_attention (bool): Whether y axis's attention or not
-        double_cross_attention (bool): Whether double cross attention or not
     """
 
-    def __init__(
-        self,
-        in_channels: int,
-        y_attention: bool = False,
-    ):
+    def __init__(self, in_channels: int, y_attention: bool = False):
         super(Attention1D, self).__init__()
         self.y_attention = y_attention
 
         self.self_attn = AttentionLayer(in_channels, not y_attention)
-
+        self.cross_attn = AttentionLayer(in_channels, y_attention)
         self.query_conv = nn.Conv2d(in_channels, in_channels, 1)
         self.key_conv = nn.Conv2d(in_channels, in_channels, 1)
 
@@ -110,53 +104,15 @@ class Attention1D(BaseModule):
 
     def forward(self, feature1, feature2, position, value):
         """Forward function for Attention1D.
-        Key: feature2 + position
-        Value: feature2
-        Query: self attention feature1 + position
 
-                Args:
-                    feature1 (Tensor): The input feature1.
-                    feature2 (Tensor): The input feature2.
-                    position (Tensor): position encoding.
-                    value (Tensor): attention value.
-                Returns:
-
-                """
-        b, c, h, w = feature1.size()
-
-        feature1 = self.self_attn(feature1, position, value)[0]
-
-        query = feature1 + position if position is not None else feature1
-        query = self.query_conv(query)
-
-        key = feature2 + position if position is not None else feature2
-        key = self.key_conv(key)
-
-        value = feature2 if value is None else value
-        scale_factor = c**0.5
-
-        if self.y_attention:
-            # multiple on H direction
-            query = query.permute(0, 3, 2, 1)  # [B, W, H, C]
-            key = key.permute(0, 3, 1, 2)  # [B, W, C, H]
-            value = value.permute(0, 3, 2, 1)  # [B, W, H, C]
-        else:  # x attention
-            # multiple on W direction
-            query = query.permute(0, 2, 3, 1)  # [B, H, W, C]
-            key = key.permute(0, 2, 1, 3)  # [B, H, C, W]
-            value = value.permute(0, 2, 3, 1)  # [B, H, W, C]
-
-        scores = torch.matmul(
-            query, key) / scale_factor  # [B, W, H, H] or  [B, H, W, W]
-
-        attention = torch.softmax(
-            scores, dim=-1)  # [B, W, H, H] or  [B, H, W, W]
-
-        out = torch.matmul(attention, value)  # [B, W, H, H] or  [B, H, W, W]
-
-        if self.y_attention:
-            out = out.permute(0, 3, 2, 1).contiguous()  # [B, C, H, W]
-        else:
-            out = out.permute(0, 3, 1, 2).contiguous()  # [B, C, H, W]
-
-        return out, attention
+        Args:
+            feature1 (Tensor): The input feature1.
+            feature2 (Tensor): The input feature2.
+            position (Tensor): position encoding.
+            value (Tensor): attention value.
+        Returns:
+            out (Tensor): cross attention output
+            attention (Tensor):  cross attention of key and query
+        """
+        feature1 = self.self_attn(feature1, feature1, position, value)[0]
+        return self.cross_attn(feature1, feature2, position, value)

--- a/mmflow/models/utils/attention.py
+++ b/mmflow/models/utils/attention.py
@@ -1,9 +1,83 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import copy
 
 import torch
 from mmcv.runner import BaseModule
 from torch import nn
+
+
+class AttentionLayer(BaseModule):
+    """AttentionLayer on x or y direction, compute the self attention on y or x
+    direction.
+
+    Args:
+        in_channels (int): Number of input channels.
+        y_attention (bool): Whether y axis's attention or not
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        y_attention: bool = False,
+    ):
+        super(AttentionLayer, self).__init__()
+        self.y_attention = y_attention
+
+        self.query_conv = nn.Conv2d(in_channels, in_channels, 1)
+        self.key_conv = nn.Conv2d(in_channels, in_channels, 1)
+
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+
+    def forward(self, feature1, position, value):
+        """Forward function for Attention1D.
+        Key: feature2 + position
+        Value: feature2
+        Query: self attention feature1 + position
+
+                Args:
+                    feature1 (Tensor): The input feature1.
+                    position (Tensor): position encoding.
+                    value (Tensor): attention value.
+                Returns:
+
+                """
+        b, c, h, w = feature1.size()
+
+        query = feature1 + position if position is not None else feature1
+        query = self.query_conv(query)
+
+        key = feature1 + position if position is not None else feature1
+        key = self.key_conv(key)
+
+        value = feature1 if value is None else value
+        scale_factor = c**0.5
+
+        if self.y_attention:
+            # multiple on H direction
+            query = query.permute(0, 3, 2, 1)  # [B, W, H, C]
+            key = key.permute(0, 3, 1, 2)  # [B, W, C, H]
+            value = value.permute(0, 3, 2, 1)  # [B, W, H, C]
+        else:  # x attention
+            # multiple on W direction
+            query = query.permute(0, 2, 3, 1)  # [B, H, W, C]
+            key = key.permute(0, 2, 1, 3)  # [B, H, C, W]
+            value = value.permute(0, 2, 3, 1)  # [B, H, W, C]
+
+        scores = torch.matmul(
+            query, key) / scale_factor  # [B, W, H, H] or  [B, H, W, W]
+
+        attention = torch.softmax(
+            scores, dim=-1)  # [B, W, H, H] or  [B, H, W, W]
+
+        out = torch.matmul(attention, value)  # [B, W, H, H] or  [B, H, W, W]
+
+        if self.y_attention:
+            out = out.permute(0, 3, 2, 1).contiguous()  # [B, C, H, W]
+        else:
+            out = out.permute(0, 3, 1, 2).contiguous()  # [B, C, H, W]
+
+        return out, attention
 
 
 class Attention1D(BaseModule):
@@ -21,19 +95,11 @@ class Attention1D(BaseModule):
         self,
         in_channels: int,
         y_attention: bool = False,
-        double_cross_attention: bool = False,
     ):
         super(Attention1D, self).__init__()
         self.y_attention = y_attention
-        self.double_cross_attention = double_cross_attention
 
-        # do self attention first
-        if double_cross_attention:
-            self.self_attn = copy.deepcopy(
-                Attention1D(
-                    in_channels,
-                    y_attention=not y_attention,
-                ))
+        self.self_attn = AttentionLayer(in_channels, not y_attention)
 
         self.query_conv = nn.Conv2d(in_channels, in_channels, 1)
         self.key_conv = nn.Conv2d(in_channels, in_channels, 1)
@@ -58,8 +124,7 @@ class Attention1D(BaseModule):
                 """
         b, c, h, w = feature1.size()
 
-        if self.double_cross_attention:
-            feature1 = self.self_attn(feature1, feature1, position, value)[0]
+        feature1 = self.self_attn(feature1, position, value)[0]
 
         query = feature1 + position if position is not None else feature1
         query = self.query_conv(query)

--- a/mmflow/models/utils/attention1d.py
+++ b/mmflow/models/utils/attention1d.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import torch
 from mmcv.runner import BaseModule
-from torch import nn
+from torch import Tensor, nn
 
 
 class AttentionLayer(BaseModule):
@@ -26,9 +26,8 @@ class AttentionLayer(BaseModule):
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
 
-    def forward(self, feature1: torch.Tensor, feature2: torch.Tensor,
-                position: torch.Tensor,
-                value: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, feature1: Tensor, feature2: Tensor, position: Tensor,
+                value: Tensor) -> Tuple[Tensor, Tensor]:
         """Forward function for AttentionLayer.
 
         Query: feature1 + position
@@ -42,7 +41,7 @@ class AttentionLayer(BaseModule):
             value (Tensor): attention value.
 
         Returns:
-            Tuple[torch.Tensor, torch.Tensor]: The output of attention layer
+            Tuple[Tensor, Tensor]: The output of attention layer
             and attention weights (scores).
         """
         b, c, h, w = feature1.size()
@@ -104,9 +103,8 @@ class Attention1D(BaseModule):
             self.self_attn = AttentionLayer(in_channels, not y_attention)
         self.cross_attn = AttentionLayer(in_channels, y_attention)
 
-    def forward(self, feature1: torch.Tensor, feature2: torch.Tensor,
-                position: torch.Tensor,
-                value: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, feature1: Tensor, feature2: Tensor, position: Tensor,
+                value: Tensor) -> Tuple[Tensor, Tensor]:
         """Forward function for Attention1D.
 
         Args:
@@ -116,7 +114,7 @@ class Attention1D(BaseModule):
             value (Tensor): attention value.
 
         Returns:
-            Tuple[torch.Tensor, torch.Tensor]: The output of attention layer
+            Tuple[Tensor, Tensor]: The output of attention layer
             and attention weights (scores).
         """
         if self.double_cross_attn:

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -12,7 +12,7 @@ def test_attention():
     #  test cross attention y
     attn_y = Attention1D(in_channels=3, y_attention=True)
     # test x's self attention first
-    selfattn_x, _ = attn_y.self_attn(feature1, None, None)
+    selfattn_x, _ = attn_y.self_attn(feature1, feature1, None, None)
     assert selfattn_x.size() == (b, c, h, w)
     feature2_y, attention_y = attn_y.forward(feature1, feature2, None, None)
     assert feature2_y.size() == (b, c, h, w)
@@ -21,7 +21,7 @@ def test_attention():
     #  test cross attention x
     attn_x = Attention1D(in_channels=3, y_attention=False)
     # test y's self attention first
-    selfattn_y, _ = attn_x.self_attn(feature1, None, None)
+    selfattn_y, _ = attn_x.self_attn(feature1, feature1, None, None)
     assert selfattn_y.size() == (b, c, h, w)
     feature2_x, attention_x = attn_x.forward(feature1, feature2, None, None)
     assert feature2_x.size() == (b, c, h, w)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -1,0 +1,30 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
+from mmflow.models.utils.attention import Attention1D
+
+
+def test_attention():
+    feature1 = torch.randn(1, 3, 2, 4)
+    feature2 = torch.randn(1, 3, 2, 4)
+    b, c, h, w = feature1.size()
+
+    #  test cross attention y
+    attn_y = Attention1D(
+        in_channels=3, y_attention=True, double_cross_attention=True)
+    # test x's self attention first
+    selfattn_x, _ = attn_y.self_attn(feature1, feature1, None, None)
+    assert selfattn_x.size() == (b, c, h, w)
+    feature2_y, attention_y = attn_y.forward(feature1, feature2, None, None)
+    assert feature2_y.size() == (b, c, h, w)
+    assert attention_y.size() == (b, w, h, h)
+
+    #  test cross attention x
+    attn_x = Attention1D(
+        in_channels=3, y_attention=False, double_cross_attention=True)
+    # test y's self attention first
+    selfattn_y, _ = attn_x.self_attn(feature1, feature1, None, None)
+    assert selfattn_y.size() == (b, c, h, w)
+    feature2_x, attention_x = attn_x.forward(feature1, feature2, None, None)
+    assert feature2_x.size() == (b, c, h, w)
+    assert attention_x.size() == (b, h, w, w)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -48,7 +48,8 @@ def test_attentionLayer(y_attention):
 
 
 @pytest.mark.parametrize('y_attention', [True, False])
-def test_attention1d(y_attention):
+@pytest.mark.parametrize('double_cross_attn', [True, False])
+def test_attention1d(y_attention, double_cross_attn):
     # ground truth
     gt_out_x = Tensor([[[[1.9991, 1.9999], [3.9991, 3.9999]]]])
     gt_scores_x = Tensor([[[[9.2010e-04, 9.9908e-01], [1.2342e-04,
@@ -62,34 +63,57 @@ def test_attention1d(y_attention):
                            [[4.6630e-05, 9.9995e-01], [1.5237e-08,
                                                        1.0000e+00]]]])
     gt_selfattn_x = Tensor([[[[0.9526, 0.9933], [2.9991, 2.9999]]]])
+    gt_singleattn_out_y = Tensor([[[[2.9951, 3.9999], [3.0000, 4.0000]]]])
+    gt_singleattn_scores_y = Tensor([[[[2.4726e-03, 9.9753e-01],
+                                       [8.3153e-07, 1.0000e+00]],
+                                      [[4.5398e-05, 9.9995e-01],
+                                       [1.5230e-08, 1.0000e+00]]]])
+    gt_singleattn_out_x = Tensor([[[[1.9526, 1.9933], [3.9991, 3.9999]]]])
+    gt_singleattn_scores_x = Tensor([[[[4.7426e-02, 9.5257e-01],
+                                       [6.6929e-03, 9.9331e-01]],
+                                      [[9.1105e-04, 9.9909e-01],
+                                       [1.2339e-04, 9.9988e-01]]]])
 
     # initialize Attention1D
     attn = Attention1D(
-        in_channels=c, y_attention=y_attention, double_cross_attn=True)
+        in_channels=c,
+        y_attention=y_attention,
+        double_cross_attn=double_cross_attn)
 
     # setting weights
-    attn.self_attn.query_conv.weight.data = Tensor([[[[1.]]]])
     attn.cross_attn.query_conv.weight.data = Tensor([[[[1.]]]])
-    attn.self_attn.query_conv.bias.data = Tensor([1.5])
     attn.cross_attn.query_conv.bias.data = Tensor([1.5])
-    attn.self_attn.key_conv.weight.data = Tensor([[[[2.]]]])
     attn.cross_attn.key_conv.weight.data = Tensor([[[[2.]]]])
-    attn.self_attn.key_conv.bias.data = Tensor([-1.])
     attn.cross_attn.key_conv.bias.data = Tensor([-1.])
+    if double_cross_attn:
+        attn.self_attn.query_conv.weight.data = Tensor([[[[1.]]]])
+        attn.self_attn.query_conv.bias.data = Tensor([1.5])
+        attn.self_attn.key_conv.weight.data = Tensor([[[[2.]]]])
+        attn.self_attn.key_conv.bias.data = Tensor([-1.])
+        selfattn, _ = attn.self_attn(_feature1, _feature1, None, None)
 
     # test attention
-    selfattn, _ = attn.self_attn(_feature1, _feature1, None, None)
     out, scores = attn.forward(_feature1, _feature2, None, None)
     assert out.size() == (b, c, h, w)
-    if y_attention:
-        assert selfattn.size() == (b, c, h, w)
-        assert torch.allclose(selfattn, gt_selfattn_x, atol=1e-04)
-        assert scores.size() == (b, w, h, h)
-        assert torch.allclose(out, gt_out_y, atol=1e-04)
-        assert torch.allclose(scores, gt_scores_y, atol=1e-04)
+    if double_cross_attn:
+        if y_attention:
+            assert selfattn.size() == (b, c, h, w)
+            assert torch.allclose(selfattn, gt_selfattn_x, atol=1e-04)
+            assert scores.size() == (b, w, h, h)
+            assert torch.allclose(out, gt_out_y, atol=1e-04)
+            assert torch.allclose(scores, gt_scores_y, atol=1e-04)
+        else:
+            assert selfattn.size() == (b, c, h, w)
+            assert torch.allclose(selfattn, gt_selfattn_y, atol=1e-04)
+            assert scores.size() == (b, h, w, w)
+            assert torch.allclose(out, gt_out_x, atol=1e-04)
+            assert torch.allclose(scores, gt_scores_x, atol=1e-04)
     else:
-        assert selfattn.size() == (b, c, h, w)
-        assert torch.allclose(selfattn, gt_selfattn_y, atol=1e-04)
-        assert scores.size() == (b, h, w, w)
-        assert torch.allclose(out, gt_out_x, atol=1e-04)
-        assert torch.allclose(scores, gt_scores_x, atol=1e-04)
+        if y_attention:
+            assert scores.size() == (b, w, h, h)
+            assert torch.allclose(out, gt_singleattn_out_y, atol=1e-04)
+            assert torch.allclose(scores, gt_singleattn_scores_y, atol=1e-04)
+        else:
+            assert scores.size() == (b, h, w, w)
+            assert torch.allclose(out, gt_singleattn_out_x, atol=1e-04)
+            assert torch.allclose(scores, gt_singleattn_scores_x, atol=1e-04)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -1,28 +1,95 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from collections import OrderedDict
+
 import torch
+from torch import tensor
 
 from mmflow.models.utils.attention import Attention1D
 
 
 def test_attention():
-    feature1 = torch.randn(1, 3, 2, 4)
-    feature2 = torch.randn(1, 3, 2, 4)
+    feature1 = torch.tensor([[[[1.4851, -0.0514, -0.9695, -0.1100],
+                               [-0.3388, -1.3190, 0.1436, -0.6746]],
+                              [[-0.4149, 0.5351, -0.5995, -0.8030],
+                               [2.2214, -1.0711, -0.9920, -1.4901]],
+                              [[-0.0287, 0.2969, -0.4293, -0.6187],
+                               [-0.1972, 0.0687, -0.5300, 0.1617]]]])
+    feature2 = torch.tensor([[[[-0.4095, 1.8635, -0.7602, 0.4474],
+                               [1.1612, -0.0092, -0.7034, -0.2123]],
+                              [[1.8637, 0.8363, 1.5985, 0.5270],
+                               [1.3758, 0.2204, -0.4623, 1.6197]],
+                              [[-1.6217, 1.8201, 0.9509, -2.5758],
+                               [-1.0160, -0.2388, -0.3180, 0.1021]]]])
+
+    # feature shape (1, 3, 2, 4)
     b, c, h, w = feature1.size()
 
     #  test cross attention y
     attn_y = Attention1D(in_channels=3, y_attention=True)
+    state_dict = OrderedDict([
+        ('self_attn.query_conv.weight',
+         tensor([[[[-0.0962]], [[-0.3709]], [[-0.1936]]],
+                 [[[0.4256]], [[-0.2761]], [[0.5265]]],
+                 [[[-0.5304]], [[-0.0033]], [[-0.7552]]]])),
+        ('self_attn.query_conv.bias', tensor([0.5679, -0.5169, -0.5476])),
+        ('self_attn.key_conv.weight',
+         tensor([[[[0.9883]], [[-0.7814]], [[0.8251]]],
+                 [[[-0.3207]], [[-0.7325]], [[-0.5771]]],
+                 [[[-0.7312]], [[-0.1323]], [[-0.2281]]]])),
+        ('self_attn.key_conv.bias', tensor([-0.1655, -0.4254, -0.3746])),
+        ('cross_attn.query_conv.weight',
+         tensor([[[[0.5491]], [[-0.7741]], [[-0.2849]]],
+                 [[[-0.6808]], [[-0.0640]], [[0.3206]]],
+                 [[[0.8917]], [[0.5406]], [[-0.3645]]]])),
+        ('cross_attn.query_conv.bias', tensor([0.1521, -0.3843, -0.5711])),
+        ('cross_attn.key_conv.weight',
+         tensor([[[[0.7493]], [[-0.5769]], [[0.8654]]],
+                 [[[0.7737]], [[0.4463]], [[-0.7268]]],
+                 [[[-0.2483]], [[0.3091]], [[0.3188]]]])),
+        ('cross_attn.key_conv.bias', tensor([0.2244, 0.3538, -0.0416]))
+    ])
+    attn_y.load_state_dict(state_dict)
+
     # test x's self attention first
     selfattn_x, _ = attn_y.self_attn(feature1, feature1, None, None)
     assert selfattn_x.size() == (b, c, h, w)
+
+    # cross attention on y direction
     feature2_y, attention_y = attn_y.forward(feature1, feature2, None, None)
     assert feature2_y.size() == (b, c, h, w)
     assert attention_y.size() == (b, w, h, h)
 
     #  test cross attention x
     attn_x = Attention1D(in_channels=3, y_attention=False)
+    state_dict = OrderedDict([
+        ('self_attn.query_conv.weight',
+         tensor([[[[-0.2707]], [[0.8776]], [[0.2155]]],
+                 [[[0.4508]], [[-0.3846]], [[0.4017]]],
+                 [[[0.4647]], [[-0.5446]], [[0.8714]]]])),
+        ('self_attn.query_conv.bias', tensor([-0.3693, -0.0481, -0.4405])),
+        ('self_attn.key_conv.weight',
+         tensor([[[[0.2769]], [[-0.6740]], [[0.0146]]],
+                 [[[0.2338]], [[-0.7720]], [[-0.9872]]],
+                 [[[0.0912]], [[-0.8806]], [[-0.9097]]]])),
+        ('self_attn.key_conv.bias', tensor([0.4059, -0.5126, -0.3617])),
+        ('cross_attn.query_conv.weight',
+         tensor([[[[-0.9078]], [[0.1079]], [[0.5150]]],
+                 [[[0.4239]], [[-0.8712]], [[-0.9505]]],
+                 [[[-0.0483]], [[-0.9157]], [[-0.0928]]]])),
+        ('cross_attn.query_conv.bias', tensor([0.1816, 0.3177, -0.3526])),
+        ('cross_attn.key_conv.weight',
+         tensor([[[[-0.6112]], [[-0.1017]], [[-0.9844]]],
+                 [[[0.7257]], [[-0.8277]], [[0.3744]]],
+                 [[[-0.9275]], [[-0.9794]], [[-0.8065]]]])),
+        ('cross_attn.key_conv.bias', tensor([-0.0744, -0.3446, 0.2543]))
+    ])
+    attn_x.load_state_dict(state_dict)
+
     # test y's self attention first
     selfattn_y, _ = attn_x.self_attn(feature1, feature1, None, None)
     assert selfattn_y.size() == (b, c, h, w)
+
+    # cross attention on x direction
     feature2_x, attention_x = attn_x.forward(feature1, feature2, None, None)
     assert feature2_x.size() == (b, c, h, w)
     assert attention_x.size() == (b, h, w, w)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -1,117 +1,95 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-
+import pytest
 import torch
+from torch import Tensor
 
 from mmflow.models.utils.attention1d import Attention1D, AttentionLayer
 
+_feature1 = Tensor([[[[0., 1.], [2., 3.]]]])
+_feature2 = Tensor([[[[1., 2.], [3., 4.]]]])
 
-def test_attentionLayer():
-    feature1 = torch.tensor([[[[0., 1.], [2., 3.]]]])
-    feature2 = torch.tensor([[[[1., 2.], [3., 4.]]]])
-
-    # feature shape (1, 1, 2, 2)
-    b, c, h, w = feature1.size()
-    attn_layer_y = AttentionLayer(in_channels=c, y_attention=True)
-    attn_layer_x = AttentionLayer(in_channels=c, y_attention=False)
-
-    # ground truth
-    feature_x_gt = torch.Tensor([[[[1.9526, 1.9933], [3.9991, 3.9999]]]])
-    attention_x_gt = torch.Tensor([[[[4.7426e-02, 9.5257e-01],
-                                     [6.6929e-03, 9.9331e-01]],
-                                    [[9.1105e-04, 9.9909e-01],
-                                     [1.2339e-04, 9.9988e-01]]]])
-    feature_y_gt = torch.Tensor([[[[2.9951, 3.9999], [3.0000, 4.0000]]]])
-    attention_y_gt = torch.Tensor([[[[2.4726e-03, 9.9753e-01],
-                                     [8.3153e-07, 1.0000e+00]],
-                                    [[4.5398e-05, 9.9995e-01],
-                                     [1.5230e-08, 1.0000e+00]]]])
-
-    # setting weights
-    attn_layer_x.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_layer_y.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_layer_x.query_conv.bias.data = torch.Tensor([1.5])
-    attn_layer_y.query_conv.bias.data = torch.Tensor([1.5])
-    attn_layer_x.key_conv.weight.data = torch.Tensor([[[[2.]]]])
-    attn_layer_y.key_conv.weight.data = torch.Tensor([[[[2.]]]])
-    attn_layer_x.key_conv.bias.data = torch.Tensor([-1.])
-    attn_layer_y.key_conv.bias.data = torch.Tensor([-1.])
-
-    feature_y, attention_y = attn_layer_y(feature1, feature2, None, None)
-    feature_x, attention_x = attn_layer_x(feature1, feature2, None, None)
-    assert (b, c, h, w) == feature_x.size()
-    assert torch.allclose(feature_x, feature_x_gt, atol=1e-04)
-    assert torch.allclose(attention_x, attention_x_gt, atol=1e-04)
-    assert (b, c, h, w) == feature_y.size()
-    assert torch.allclose(feature_y, feature_y_gt, atol=1e-04)
-    assert torch.allclose(attention_y, attention_y_gt, atol=1e-04)
+# feature shape (1, 1, 2, 2)
+b, c, h, w = _feature1.size()
 
 
-def test_attention1d():
-    feature1 = torch.tensor([[[[0., 1.], [2., 3.]]]])
-    feature2 = torch.tensor([[[[1., 2.], [3., 4.]]]])
-
-    # feature shape (1, 1, 2, 2)
-    b, c, h, w = feature1.size()
+@pytest.mark.parametrize('y_attention', [True, False])
+def test_attentionLayer(y_attention):
+    attn_layer = AttentionLayer(in_channels=c, y_attention=y_attention)
 
     # ground truth
-    feature2_x_gt = torch.Tensor([[[[1.9991, 1.9999], [3.9991, 3.9999]]]])
-    attention_x_gt = torch.Tensor([[[[9.2010e-04, 9.9908e-01],
-                                     [1.2342e-04, 9.9988e-01]],
-                                    [[9.1105e-04, 9.9909e-01],
-                                     [1.2339e-04, 9.9988e-01]]]])
-    selfattn_y_gt = torch.Tensor([[[[1.9951, 2.9999], [2.0000, 3.0000]]]])
-    feature2_y_gt = torch.Tensor([[[[2.9999, 3.9999], [3.0000, 4.0000]]]])
-    attention_y_gt = torch.Tensor([[[[5.4881e-05, 9.9995e-01],
-                                     [1.5286e-08, 1.0000e+00]],
-                                    [[4.6630e-05, 9.9995e-01],
-                                     [1.5237e-08, 1.0000e+00]]]])
-    selfattn_x_gt = torch.Tensor([[[[0.9526, 0.9933], [2.9991, 2.9999]]]])
-
-    # test cross attention y
-    attn_y = Attention1D(
-        in_channels=c, y_attention=True, double_cross_attn=True)
+    feature_x_gt = Tensor([[[[1.9526, 1.9933], [3.9991, 3.9999]]]])
+    attention_x_gt = Tensor([[[[4.7426e-02, 9.5257e-01],
+                               [6.6929e-03, 9.9331e-01]],
+                              [[9.1105e-04, 9.9909e-01],
+                               [1.2339e-04, 9.9988e-01]]]])
+    feature_y_gt = Tensor([[[[2.9951, 3.9999], [3.0000, 4.0000]]]])
+    attention_y_gt = Tensor([[[[2.4726e-03, 9.9753e-01],
+                               [8.3153e-07, 1.0000e+00]],
+                              [[4.5398e-05, 9.9995e-01],
+                               [1.5230e-08, 1.0000e+00]]]])
 
     # setting weights
-    attn_y.self_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_y.cross_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_y.self_attn.query_conv.bias.data = torch.Tensor([1.5])
-    attn_y.cross_attn.query_conv.bias.data = torch.Tensor([1.5])
-    attn_y.self_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
-    attn_y.cross_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
-    attn_y.self_attn.key_conv.bias.data = torch.Tensor([-1.])
-    attn_y.cross_attn.key_conv.bias.data = torch.Tensor([-1.])
+    attn_layer.query_conv.weight.data = Tensor([[[[1.]]]])
+    attn_layer.query_conv.bias.data = Tensor([1.5])
+    attn_layer.key_conv.weight.data = Tensor([[[[2.]]]])
+    attn_layer.key_conv.bias.data = Tensor([-1.])
 
-    # test x's self attention first
-    selfattn_x, _ = attn_y.self_attn(feature1, feature1, None, None)
-    assert selfattn_x.size() == (b, c, h, w)
-    assert torch.allclose(selfattn_x, selfattn_x_gt, atol=1e-04)
-    # cross attention on y direction
-    feature2_y, attention_y = attn_y.forward(feature1, feature2, None, None)
-    assert feature2_y.size() == (b, c, h, w)
-    assert attention_y.size() == (b, w, h, h)
-    assert torch.allclose(feature2_y, feature2_y_gt, atol=1e-04)
-    assert torch.allclose(attention_y, attention_y_gt, atol=1e-04)
+    out, scores = attn_layer(_feature1, _feature2, None, None)
+    assert out.size() == (b, c, h, w)
+    if y_attention:
+        assert scores.size() == (b, w, h, h)
+        assert torch.allclose(out, feature_y_gt, atol=1e-04)
+        assert torch.allclose(scores, attention_y_gt, atol=1e-4)
 
-    #  test cross attention x
-    attn_x = Attention1D(in_channels=c, y_attention=False)
+    else:
+        assert scores.size() == (b, h, w, w)
+        assert torch.allclose(out, feature_x_gt, atol=1e-04)
+        assert torch.allclose(scores, attention_x_gt, atol=1e-4)
+
+
+@pytest.mark.parametrize('y_attention', [True, False])
+def test_attention1d(y_attention):
+    # ground truth
+    feature2_x_gt = Tensor([[[[1.9991, 1.9999], [3.9991, 3.9999]]]])
+    attention_x_gt = Tensor([[[[9.2010e-04, 9.9908e-01],
+                               [1.2342e-04, 9.9988e-01]],
+                              [[9.1105e-04, 9.9909e-01],
+                               [1.2339e-04, 9.9988e-01]]]])
+    selfattn_y_gt = Tensor([[[[1.9951, 2.9999], [2.0000, 3.0000]]]])
+    feature2_y_gt = Tensor([[[[2.9999, 3.9999], [3.0000, 4.0000]]]])
+    attention_y_gt = Tensor([[[[5.4881e-05, 9.9995e-01],
+                               [1.5286e-08, 1.0000e+00]],
+                              [[4.6630e-05, 9.9995e-01],
+                               [1.5237e-08, 1.0000e+00]]]])
+    selfattn_x_gt = Tensor([[[[0.9526, 0.9933], [2.9991, 2.9999]]]])
+
+    # initialize Attention1D
+    attn = Attention1D(
+        in_channels=c, y_attention=y_attention, double_cross_attn=True)
 
     # setting weights
-    attn_x.self_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_x.cross_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_x.self_attn.query_conv.bias.data = torch.Tensor([1.5])
-    attn_x.cross_attn.query_conv.bias.data = torch.Tensor([1.5])
-    attn_x.self_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
-    attn_x.cross_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
-    attn_x.self_attn.key_conv.bias.data = torch.Tensor([-1.])
-    attn_x.cross_attn.key_conv.bias.data = torch.Tensor([-1.])
+    attn.self_attn.query_conv.weight.data = Tensor([[[[1.]]]])
+    attn.cross_attn.query_conv.weight.data = Tensor([[[[1.]]]])
+    attn.self_attn.query_conv.bias.data = Tensor([1.5])
+    attn.cross_attn.query_conv.bias.data = Tensor([1.5])
+    attn.self_attn.key_conv.weight.data = Tensor([[[[2.]]]])
+    attn.cross_attn.key_conv.weight.data = Tensor([[[[2.]]]])
+    attn.self_attn.key_conv.bias.data = Tensor([-1.])
+    attn.cross_attn.key_conv.bias.data = Tensor([-1.])
 
-    # test y's self attention first
-    selfattn_y, _ = attn_x.self_attn(feature1, feature1, None, None)
-    assert selfattn_y.size() == (b, c, h, w)
-    assert torch.allclose(selfattn_y, selfattn_y_gt, atol=1e-04)
-    # cross attention on x direction
-    feature2_x, attention_x = attn_x.forward(feature1, feature2, None, None)
-    assert feature2_x.size() == (b, c, h, w)
-    assert attention_x.size() == (b, h, w, w)
-    assert torch.allclose(feature2_x, feature2_x_gt, atol=1e-04)
-    assert torch.allclose(attention_x, attention_x_gt, atol=1e-04)
+    # test attention
+    selfattn, _ = attn.self_attn(_feature1, _feature1, None, None)
+    out, attention = attn.forward(_feature1, _feature2, None, None)
+    assert out.size() == (b, c, h, w)
+    if y_attention:
+        assert selfattn.size() == (b, c, h, w)
+        assert torch.allclose(selfattn, selfattn_x_gt, atol=1e-04)
+        assert attention.size() == (b, w, h, h)
+        assert torch.allclose(out, feature2_y_gt, atol=1e-04)
+        assert torch.allclose(attention, attention_y_gt, atol=1e-04)
+    else:
+        assert selfattn.size() == (b, c, h, w)
+        assert torch.allclose(selfattn, selfattn_y_gt, atol=1e-04)
+        assert attention.size() == (b, h, w, w)
+        assert torch.allclose(out, feature2_x_gt, atol=1e-04)
+        assert torch.allclose(attention, attention_x_gt, atol=1e-04)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -17,16 +17,16 @@ def test_attentionLayer(y_attention):
     attn_layer = AttentionLayer(in_channels=c, y_attention=y_attention)
 
     # ground truth
-    feature_x_gt = Tensor([[[[1.9526, 1.9933], [3.9991, 3.9999]]]])
-    attention_x_gt = Tensor([[[[4.7426e-02, 9.5257e-01],
-                               [6.6929e-03, 9.9331e-01]],
-                              [[9.1105e-04, 9.9909e-01],
-                               [1.2339e-04, 9.9988e-01]]]])
-    feature_y_gt = Tensor([[[[2.9951, 3.9999], [3.0000, 4.0000]]]])
-    attention_y_gt = Tensor([[[[2.4726e-03, 9.9753e-01],
-                               [8.3153e-07, 1.0000e+00]],
-                              [[4.5398e-05, 9.9995e-01],
-                               [1.5230e-08, 1.0000e+00]]]])
+    gt_out_x = Tensor([[[[1.9526, 1.9933], [3.9991, 3.9999]]]])
+    gt_scores_x = Tensor([[[[4.7426e-02, 9.5257e-01], [6.6929e-03,
+                                                       9.9331e-01]],
+                           [[9.1105e-04, 9.9909e-01], [1.2339e-04,
+                                                       9.9988e-01]]]])
+    gt_out_y = Tensor([[[[2.9951, 3.9999], [3.0000, 4.0000]]]])
+    gt_scores_y = Tensor([[[[2.4726e-03, 9.9753e-01], [8.3153e-07,
+                                                       1.0000e+00]],
+                           [[4.5398e-05, 9.9995e-01], [1.5230e-08,
+                                                       1.0000e+00]]]])
 
     # setting weights
     attn_layer.query_conv.weight.data = Tensor([[[[1.]]]])
@@ -38,30 +38,30 @@ def test_attentionLayer(y_attention):
     assert out.size() == (b, c, h, w)
     if y_attention:
         assert scores.size() == (b, w, h, h)
-        assert torch.allclose(out, feature_y_gt, atol=1e-04)
-        assert torch.allclose(scores, attention_y_gt, atol=1e-4)
+        assert torch.allclose(out, gt_out_y, atol=1e-04)
+        assert torch.allclose(scores, gt_scores_y, atol=1e-4)
 
     else:
         assert scores.size() == (b, h, w, w)
-        assert torch.allclose(out, feature_x_gt, atol=1e-04)
-        assert torch.allclose(scores, attention_x_gt, atol=1e-4)
+        assert torch.allclose(out, gt_out_x, atol=1e-04)
+        assert torch.allclose(scores, gt_scores_x, atol=1e-4)
 
 
 @pytest.mark.parametrize('y_attention', [True, False])
 def test_attention1d(y_attention):
     # ground truth
-    feature2_x_gt = Tensor([[[[1.9991, 1.9999], [3.9991, 3.9999]]]])
-    attention_x_gt = Tensor([[[[9.2010e-04, 9.9908e-01],
-                               [1.2342e-04, 9.9988e-01]],
-                              [[9.1105e-04, 9.9909e-01],
-                               [1.2339e-04, 9.9988e-01]]]])
-    selfattn_y_gt = Tensor([[[[1.9951, 2.9999], [2.0000, 3.0000]]]])
-    feature2_y_gt = Tensor([[[[2.9999, 3.9999], [3.0000, 4.0000]]]])
-    attention_y_gt = Tensor([[[[5.4881e-05, 9.9995e-01],
-                               [1.5286e-08, 1.0000e+00]],
-                              [[4.6630e-05, 9.9995e-01],
-                               [1.5237e-08, 1.0000e+00]]]])
-    selfattn_x_gt = Tensor([[[[0.9526, 0.9933], [2.9991, 2.9999]]]])
+    gt_out_x = Tensor([[[[1.9991, 1.9999], [3.9991, 3.9999]]]])
+    gt_scores_x = Tensor([[[[9.2010e-04, 9.9908e-01], [1.2342e-04,
+                                                       9.9988e-01]],
+                           [[9.1105e-04, 9.9909e-01], [1.2339e-04,
+                                                       9.9988e-01]]]])
+    gt_selfattn_y = Tensor([[[[1.9951, 2.9999], [2.0000, 3.0000]]]])
+    gt_out_y = Tensor([[[[2.9999, 3.9999], [3.0000, 4.0000]]]])
+    gt_scores_y = Tensor([[[[5.4881e-05, 9.9995e-01], [1.5286e-08,
+                                                       1.0000e+00]],
+                           [[4.6630e-05, 9.9995e-01], [1.5237e-08,
+                                                       1.0000e+00]]]])
+    gt_selfattn_x = Tensor([[[[0.9526, 0.9933], [2.9991, 2.9999]]]])
 
     # initialize Attention1D
     attn = Attention1D(
@@ -79,17 +79,17 @@ def test_attention1d(y_attention):
 
     # test attention
     selfattn, _ = attn.self_attn(_feature1, _feature1, None, None)
-    out, attention = attn.forward(_feature1, _feature2, None, None)
+    out, scores = attn.forward(_feature1, _feature2, None, None)
     assert out.size() == (b, c, h, w)
     if y_attention:
         assert selfattn.size() == (b, c, h, w)
-        assert torch.allclose(selfattn, selfattn_x_gt, atol=1e-04)
-        assert attention.size() == (b, w, h, h)
-        assert torch.allclose(out, feature2_y_gt, atol=1e-04)
-        assert torch.allclose(attention, attention_y_gt, atol=1e-04)
+        assert torch.allclose(selfattn, gt_selfattn_x, atol=1e-04)
+        assert scores.size() == (b, w, h, h)
+        assert torch.allclose(out, gt_out_y, atol=1e-04)
+        assert torch.allclose(scores, gt_scores_y, atol=1e-04)
     else:
         assert selfattn.size() == (b, c, h, w)
-        assert torch.allclose(selfattn, selfattn_y_gt, atol=1e-04)
-        assert attention.size() == (b, h, w, w)
-        assert torch.allclose(out, feature2_x_gt, atol=1e-04)
-        assert torch.allclose(attention, attention_x_gt, atol=1e-04)
+        assert torch.allclose(selfattn, gt_selfattn_y, atol=1e-04)
+        assert scores.size() == (b, h, w, w)
+        assert torch.allclose(out, gt_out_x, atol=1e-04)
+        assert torch.allclose(scores, gt_scores_x, atol=1e-04)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -1,54 +1,55 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from collections import OrderedDict
 
 import torch
-from torch import tensor
 
-from mmflow.models.utils.attention import Attention1D
+from mmflow.models.utils.attention1d import Attention1D, AttentionLayer
 
 
-def test_attention():
-    feature1 = torch.tensor([[[[1.4851, -0.0514, -0.9695, -0.1100],
-                               [-0.3388, -1.3190, 0.1436, -0.6746]],
-                              [[-0.4149, 0.5351, -0.5995, -0.8030],
-                               [2.2214, -1.0711, -0.9920, -1.4901]],
-                              [[-0.0287, 0.2969, -0.4293, -0.6187],
-                               [-0.1972, 0.0687, -0.5300, 0.1617]]]])
-    feature2 = torch.tensor([[[[-0.4095, 1.8635, -0.7602, 0.4474],
-                               [1.1612, -0.0092, -0.7034, -0.2123]],
-                              [[1.8637, 0.8363, 1.5985, 0.5270],
-                               [1.3758, 0.2204, -0.4623, 1.6197]],
-                              [[-1.6217, 1.8201, 0.9509, -2.5758],
-                               [-1.0160, -0.2388, -0.3180, 0.1021]]]])
+def test_attentionLayer():
+    feature1 = torch.tensor([[[[0., 1.], [2., 3.]]]])
+    feature2 = torch.tensor([[[[1., 2.], [3., 4.]]]])
 
-    # feature shape (1, 3, 2, 4)
+    # feature shape (1, 1, 2, 2)
+    b, c, h, w = feature1.size()
+    attn_layer_y = AttentionLayer(in_channels=c, y_attention=True)
+    attn_layer_x = AttentionLayer(in_channels=c, y_attention=False)
+
+    # setting weights
+    attn_layer_x.query_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_layer_y.query_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_layer_x.query_conv.bias.data = torch.Tensor([1.])
+    attn_layer_y.query_conv.bias.data = torch.Tensor([1.])
+    attn_layer_x.key_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_layer_y.key_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_layer_x.key_conv.bias.data = torch.Tensor([1.])
+    attn_layer_y.key_conv.bias.data = torch.Tensor([1.])
+
+    feature_y, attention_y = attn_layer_y(feature1, feature2, None, None)
+    feature_x, attention_x = attn_layer_x(feature1, feature2, None, None)
+    assert (b, c, h, w) == feature_x.size()
+    assert (b, c, h, w) == feature_y.size()
+
+
+def test_attention1d():
+    feature1 = torch.tensor([[[[0., 1.], [2., 3.]]]])
+    feature2 = torch.tensor([[[[1., 2.], [3., 4.]]]])
+
+    # feature shape (1, 1, 2, 2)
     b, c, h, w = feature1.size()
 
-    #  test cross attention y
-    attn_y = Attention1D(in_channels=3, y_attention=True)
-    state_dict = OrderedDict([
-        ('self_attn.query_conv.weight',
-         tensor([[[[-0.0962]], [[-0.3709]], [[-0.1936]]],
-                 [[[0.4256]], [[-0.2761]], [[0.5265]]],
-                 [[[-0.5304]], [[-0.0033]], [[-0.7552]]]])),
-        ('self_attn.query_conv.bias', tensor([0.5679, -0.5169, -0.5476])),
-        ('self_attn.key_conv.weight',
-         tensor([[[[0.9883]], [[-0.7814]], [[0.8251]]],
-                 [[[-0.3207]], [[-0.7325]], [[-0.5771]]],
-                 [[[-0.7312]], [[-0.1323]], [[-0.2281]]]])),
-        ('self_attn.key_conv.bias', tensor([-0.1655, -0.4254, -0.3746])),
-        ('cross_attn.query_conv.weight',
-         tensor([[[[0.5491]], [[-0.7741]], [[-0.2849]]],
-                 [[[-0.6808]], [[-0.0640]], [[0.3206]]],
-                 [[[0.8917]], [[0.5406]], [[-0.3645]]]])),
-        ('cross_attn.query_conv.bias', tensor([0.1521, -0.3843, -0.5711])),
-        ('cross_attn.key_conv.weight',
-         tensor([[[[0.7493]], [[-0.5769]], [[0.8654]]],
-                 [[[0.7737]], [[0.4463]], [[-0.7268]]],
-                 [[[-0.2483]], [[0.3091]], [[0.3188]]]])),
-        ('cross_attn.key_conv.bias', tensor([0.2244, 0.3538, -0.0416]))
-    ])
-    attn_y.load_state_dict(state_dict)
+    # test cross attention y
+    attn_y = Attention1D(
+        in_channels=c, y_attention=True, double_cross_attn=True)
+
+    # setting weights
+    attn_y.self_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_y.cross_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_y.self_attn.query_conv.bias.data = torch.Tensor([1.])
+    attn_y.cross_attn.query_conv.bias.data = torch.Tensor([1.])
+    attn_y.self_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_y.cross_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_y.self_attn.key_conv.bias.data = torch.Tensor([1.])
+    attn_y.cross_attn.key_conv.bias.data = torch.Tensor([1.])
 
     # test x's self attention first
     selfattn_x, _ = attn_y.self_attn(feature1, feature1, None, None)
@@ -60,30 +61,17 @@ def test_attention():
     assert attention_y.size() == (b, w, h, h)
 
     #  test cross attention x
-    attn_x = Attention1D(in_channels=3, y_attention=False)
-    state_dict = OrderedDict([
-        ('self_attn.query_conv.weight',
-         tensor([[[[-0.2707]], [[0.8776]], [[0.2155]]],
-                 [[[0.4508]], [[-0.3846]], [[0.4017]]],
-                 [[[0.4647]], [[-0.5446]], [[0.8714]]]])),
-        ('self_attn.query_conv.bias', tensor([-0.3693, -0.0481, -0.4405])),
-        ('self_attn.key_conv.weight',
-         tensor([[[[0.2769]], [[-0.6740]], [[0.0146]]],
-                 [[[0.2338]], [[-0.7720]], [[-0.9872]]],
-                 [[[0.0912]], [[-0.8806]], [[-0.9097]]]])),
-        ('self_attn.key_conv.bias', tensor([0.4059, -0.5126, -0.3617])),
-        ('cross_attn.query_conv.weight',
-         tensor([[[[-0.9078]], [[0.1079]], [[0.5150]]],
-                 [[[0.4239]], [[-0.8712]], [[-0.9505]]],
-                 [[[-0.0483]], [[-0.9157]], [[-0.0928]]]])),
-        ('cross_attn.query_conv.bias', tensor([0.1816, 0.3177, -0.3526])),
-        ('cross_attn.key_conv.weight',
-         tensor([[[[-0.6112]], [[-0.1017]], [[-0.9844]]],
-                 [[[0.7257]], [[-0.8277]], [[0.3744]]],
-                 [[[-0.9275]], [[-0.9794]], [[-0.8065]]]])),
-        ('cross_attn.key_conv.bias', tensor([-0.0744, -0.3446, 0.2543]))
-    ])
-    attn_x.load_state_dict(state_dict)
+    attn_x = Attention1D(in_channels=c, y_attention=False)
+
+    # setting weights
+    attn_x.self_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_x.cross_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_x.self_attn.query_conv.bias.data = torch.Tensor([1.])
+    attn_x.cross_attn.query_conv.bias.data = torch.Tensor([1.])
+    attn_x.self_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_x.cross_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
+    attn_x.self_attn.key_conv.bias.data = torch.Tensor([1.])
+    attn_x.cross_attn.key_conv.bias.data = torch.Tensor([1.])
 
     # test y's self attention first
     selfattn_y, _ = attn_x.self_attn(feature1, feature1, None, None)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -10,20 +10,18 @@ def test_attention():
     b, c, h, w = feature1.size()
 
     #  test cross attention y
-    attn_y = Attention1D(
-        in_channels=3, y_attention=True, double_cross_attention=True)
+    attn_y = Attention1D(in_channels=3, y_attention=True)
     # test x's self attention first
-    selfattn_x, _ = attn_y.self_attn(feature1, feature1, None, None)
+    selfattn_x, _ = attn_y.self_attn(feature1, None, None)
     assert selfattn_x.size() == (b, c, h, w)
     feature2_y, attention_y = attn_y.forward(feature1, feature2, None, None)
     assert feature2_y.size() == (b, c, h, w)
     assert attention_y.size() == (b, w, h, h)
 
     #  test cross attention x
-    attn_x = Attention1D(
-        in_channels=3, y_attention=False, double_cross_attention=True)
+    attn_x = Attention1D(in_channels=3, y_attention=False)
     # test y's self attention first
-    selfattn_y, _ = attn_x.self_attn(feature1, feature1, None, None)
+    selfattn_y, _ = attn_x.self_attn(feature1, None, None)
     assert selfattn_y.size() == (b, c, h, w)
     feature2_x, attention_x = attn_x.forward(feature1, feature2, None, None)
     assert feature2_x.size() == (b, c, h, w)

--- a/tests/test_models/test_utils/test_attention.py
+++ b/tests/test_models/test_utils/test_attention.py
@@ -14,20 +14,36 @@ def test_attentionLayer():
     attn_layer_y = AttentionLayer(in_channels=c, y_attention=True)
     attn_layer_x = AttentionLayer(in_channels=c, y_attention=False)
 
+    # ground truth
+    feature_x_gt = torch.Tensor([[[[1.9526, 1.9933], [3.9991, 3.9999]]]])
+    attention_x_gt = torch.Tensor([[[[4.7426e-02, 9.5257e-01],
+                                     [6.6929e-03, 9.9331e-01]],
+                                    [[9.1105e-04, 9.9909e-01],
+                                     [1.2339e-04, 9.9988e-01]]]])
+    feature_y_gt = torch.Tensor([[[[2.9951, 3.9999], [3.0000, 4.0000]]]])
+    attention_y_gt = torch.Tensor([[[[2.4726e-03, 9.9753e-01],
+                                     [8.3153e-07, 1.0000e+00]],
+                                    [[4.5398e-05, 9.9995e-01],
+                                     [1.5230e-08, 1.0000e+00]]]])
+
     # setting weights
     attn_layer_x.query_conv.weight.data = torch.Tensor([[[[1.]]]])
     attn_layer_y.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_layer_x.query_conv.bias.data = torch.Tensor([1.])
-    attn_layer_y.query_conv.bias.data = torch.Tensor([1.])
-    attn_layer_x.key_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_layer_y.key_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_layer_x.key_conv.bias.data = torch.Tensor([1.])
-    attn_layer_y.key_conv.bias.data = torch.Tensor([1.])
+    attn_layer_x.query_conv.bias.data = torch.Tensor([1.5])
+    attn_layer_y.query_conv.bias.data = torch.Tensor([1.5])
+    attn_layer_x.key_conv.weight.data = torch.Tensor([[[[2.]]]])
+    attn_layer_y.key_conv.weight.data = torch.Tensor([[[[2.]]]])
+    attn_layer_x.key_conv.bias.data = torch.Tensor([-1.])
+    attn_layer_y.key_conv.bias.data = torch.Tensor([-1.])
 
     feature_y, attention_y = attn_layer_y(feature1, feature2, None, None)
     feature_x, attention_x = attn_layer_x(feature1, feature2, None, None)
     assert (b, c, h, w) == feature_x.size()
+    assert torch.allclose(feature_x, feature_x_gt, atol=1e-04)
+    assert torch.allclose(attention_x, attention_x_gt, atol=1e-04)
     assert (b, c, h, w) == feature_y.size()
+    assert torch.allclose(feature_y, feature_y_gt, atol=1e-04)
+    assert torch.allclose(attention_y, attention_y_gt, atol=1e-04)
 
 
 def test_attention1d():
@@ -37,6 +53,20 @@ def test_attention1d():
     # feature shape (1, 1, 2, 2)
     b, c, h, w = feature1.size()
 
+    # ground truth
+    feature2_x_gt = torch.Tensor([[[[1.9991, 1.9999], [3.9991, 3.9999]]]])
+    attention_x_gt = torch.Tensor([[[[9.2010e-04, 9.9908e-01],
+                                     [1.2342e-04, 9.9988e-01]],
+                                    [[9.1105e-04, 9.9909e-01],
+                                     [1.2339e-04, 9.9988e-01]]]])
+    selfattn_y_gt = torch.Tensor([[[[1.9951, 2.9999], [2.0000, 3.0000]]]])
+    feature2_y_gt = torch.Tensor([[[[2.9999, 3.9999], [3.0000, 4.0000]]]])
+    attention_y_gt = torch.Tensor([[[[5.4881e-05, 9.9995e-01],
+                                     [1.5286e-08, 1.0000e+00]],
+                                    [[4.6630e-05, 9.9995e-01],
+                                     [1.5237e-08, 1.0000e+00]]]])
+    selfattn_x_gt = torch.Tensor([[[[0.9526, 0.9933], [2.9991, 2.9999]]]])
+
     # test cross attention y
     attn_y = Attention1D(
         in_channels=c, y_attention=True, double_cross_attn=True)
@@ -44,21 +74,23 @@ def test_attention1d():
     # setting weights
     attn_y.self_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
     attn_y.cross_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_y.self_attn.query_conv.bias.data = torch.Tensor([1.])
-    attn_y.cross_attn.query_conv.bias.data = torch.Tensor([1.])
-    attn_y.self_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_y.cross_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_y.self_attn.key_conv.bias.data = torch.Tensor([1.])
-    attn_y.cross_attn.key_conv.bias.data = torch.Tensor([1.])
+    attn_y.self_attn.query_conv.bias.data = torch.Tensor([1.5])
+    attn_y.cross_attn.query_conv.bias.data = torch.Tensor([1.5])
+    attn_y.self_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
+    attn_y.cross_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
+    attn_y.self_attn.key_conv.bias.data = torch.Tensor([-1.])
+    attn_y.cross_attn.key_conv.bias.data = torch.Tensor([-1.])
 
     # test x's self attention first
     selfattn_x, _ = attn_y.self_attn(feature1, feature1, None, None)
     assert selfattn_x.size() == (b, c, h, w)
-
+    assert torch.allclose(selfattn_x, selfattn_x_gt, atol=1e-04)
     # cross attention on y direction
     feature2_y, attention_y = attn_y.forward(feature1, feature2, None, None)
     assert feature2_y.size() == (b, c, h, w)
     assert attention_y.size() == (b, w, h, h)
+    assert torch.allclose(feature2_y, feature2_y_gt, atol=1e-04)
+    assert torch.allclose(attention_y, attention_y_gt, atol=1e-04)
 
     #  test cross attention x
     attn_x = Attention1D(in_channels=c, y_attention=False)
@@ -66,18 +98,20 @@ def test_attention1d():
     # setting weights
     attn_x.self_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
     attn_x.cross_attn.query_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_x.self_attn.query_conv.bias.data = torch.Tensor([1.])
-    attn_x.cross_attn.query_conv.bias.data = torch.Tensor([1.])
-    attn_x.self_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_x.cross_attn.key_conv.weight.data = torch.Tensor([[[[1.]]]])
-    attn_x.self_attn.key_conv.bias.data = torch.Tensor([1.])
-    attn_x.cross_attn.key_conv.bias.data = torch.Tensor([1.])
+    attn_x.self_attn.query_conv.bias.data = torch.Tensor([1.5])
+    attn_x.cross_attn.query_conv.bias.data = torch.Tensor([1.5])
+    attn_x.self_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
+    attn_x.cross_attn.key_conv.weight.data = torch.Tensor([[[[2.]]]])
+    attn_x.self_attn.key_conv.bias.data = torch.Tensor([-1.])
+    attn_x.cross_attn.key_conv.bias.data = torch.Tensor([-1.])
 
     # test y's self attention first
     selfattn_y, _ = attn_x.self_attn(feature1, feature1, None, None)
     assert selfattn_y.size() == (b, c, h, w)
-
+    assert torch.allclose(selfattn_y, selfattn_y_gt, atol=1e-04)
     # cross attention on x direction
     feature2_x, attention_x = attn_x.forward(feature1, feature2, None, None)
     assert feature2_x.size() == (b, c, h, w)
     assert attention_x.size() == (b, h, w, w)
+    assert torch.allclose(feature2_x, feature2_x_gt, atol=1e-04)
+    assert torch.allclose(attention_x, attention_x_gt, atol=1e-04)


### PR DESCRIPTION
### Motivation
It is a module to compute attention (both self attention and cross attention)

### Modification
Add mmflow/models/utils/attention.py
Add tests/test_models/test_utils/test_attention.py
### Use cases
Input: feature1 [b,c,h,w] feature2 [b,c,h,w]
Output: self-attention-x [b,c,h,w] self-attention-y [b,c,h,w]
cross-attention-y [b,c,h,w] attention-y [b,w,h,h]
cross-attention-x [b,c,h,w] attention-x [b,h,w,w]