### PR TITLE
[Fix] Fix the bug of postprocess

### DIFF
--- a/mmflow/models/decoders/base_decoder.py
+++ b/mmflow/models/decoders/base_decoder.py
@@ -79,8 +79,8 @@ class BaseDecoder(BaseModule):
                             size=(ori_H, ori_W),
                             mode='bilinear',
                             align_corners=False).squeeze(0)
-                        f[:, :, 0] = f[:, :, 0] / w_scale
-                        f[:, :, 1] = f[:, :, 1] / h_scale
+                        f[0, :, :] = f[0, :, :] / w_scale
+                        f[1, :, :] = f[1, :, :] / h_scale
                 flow_data = PixelData(**{'data': f})
                 data_sample.set_data({'pred_' + key: flow_data})
 


### PR DESCRIPTION
## Motivation
We use interpolations to resize the predicted optical flows to recover original shapes.  However, the final results are wrong due to the order of dimensions has changed compared to mmflow1.0. This PR aims to fix the bug.

## Modification
- mmflow/models/decoders/base_decoder.py