### PR TITLE
[Fix] Fix some URLs of RAFT

### DIFF
--- a/configs/raft/README.md
+++ b/configs/raft/README.md
@@ -101,9 +101,9 @@ is available at https://github.com/princeton-vl/RAFT.
             <th>-</th>
             <th>1.45%</th>
             <th>0.61</th>
-            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_368x768.log.json'>log</a></th>
-            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_368x768.py'>Config</a></th>
-            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_368x768.pth'>Model</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.log.json'>log</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.py'>Config</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.pth'>Model</a></th>
         </tr>
     </tbody>
 </table>

--- a/configs/raft/metafile.yml
+++ b/configs/raft/metafile.yml
@@ -110,4 +110,4 @@ Models:
         Metrics:
           EPE: 0.61
           Fl-all: 1.45%
-    Weights: https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_368x768.pth
+    Weights: https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.pth


### PR DESCRIPTION
## Motivation
The config raft_8x2_50k_kitti2015_288x960 related URLs in README.md and metafile.yml are wrong, which may cause confusions.

## Modification
1. configs/raft/README.md
2. configs/raft/metafile.yml

## TODO
Rename the files in cloud:
1. `raft_8x2_50k_kitti2015_368x768.log.json` -> `raft_8x2_50k_kitti2015_288x960.log.json`
2. `raft_8x2_50k_kitti2015_368x768.py` -> `raft_8x2_50k_kitti2015_288x960.py`
3. `raft_8x2_50k_kitti2015_368x768.pth` -> `raft_8x2_50k_kitti2015_288x960.pth`