### PR TITLE
[Fix] Fix some URLs of RAFT(MMFlow 1.0)

### DIFF
--- a/configs/liteflownet/metafile.yml
+++ b/configs/liteflownet/metafile.yml
@@ -71,7 +71,7 @@ Models:
         Dataset: FlyingChairs
         Metrics:
           EPE: 1.71
-    Weights:
+    Weights: https://download.openmmlab.com/mmflow/liteflownet/liteflownet_pre_M3S3R3_8x1_flyingchairs_320x448.pth
 
   - Name: liteflownet_pre_M2S2R2_8x1_flyingchairs_320x448
     In Collection: LiteFlowNet

--- a/configs/raft/README.md
+++ b/configs/raft/README.md
@@ -101,9 +101,9 @@ is available at https://github.com/princeton-vl/RAFT.
             <th>-</th>
             <th>1.45%</th>
             <th>0.61</th>
-            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_368x768.log.json'>log</a></th>
-            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_368x768.py'>Config</a></th>
-            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_368x768.pth'>Model</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.log.json'>log</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.py'>Config</a></th>
+            <th><a href='https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.pth'>Model</a></th>
         </tr>
     </tbody>
 </table>

--- a/configs/raft/metafile.yml
+++ b/configs/raft/metafile.yml
@@ -97,3 +97,17 @@ Models:
           EPE: 1.59
           Fl-all: 5.68%
     Weights: https://download.openmmlab.com/mmflow/raft/raft_8x2_100k_mixed_368x768.pth
+
+  - Name: raft_8x2_50k_kitti2015_288x960
+    In Collection: RAFT
+    Config: configs/raft/raft_8x2_50k_kitti2015_288x960.py
+    Metadata:
+      Training Data:
+        - KITTI2015
+    Results:
+      - Task: Optical flow estimation
+        Dataset: KITTI2015
+        Metrics:
+          EPE: 0.61
+          Fl-all: 1.45%
+    Weights: https://download.openmmlab.com/mmflow/raft/raft_8x2_50k_kitti2015_288x960.pth


### PR DESCRIPTION
## Motivation
The config raft_8x2_50k_kitti2015_288x960 related URLs in README.md and metafile.yml are wrong, which may cause confusions.

## Modification
1. configs/raft/README.md
2. configs/raft/metafile.yml
3. configs/liteflownet/metafile.yml

## TODO
Rename the files in cloud:
1. `raft_8x2_50k_kitti2015_368x768.log.json` -> `raft_8x2_50k_kitti2015_288x960.log.json`
2. `raft_8x2_50k_kitti2015_368x768.py` -> `raft_8x2_50k_kitti2015_288x960.py`
4. `raft_8x2_50k_kitti2015_368x768.pth` -> `raft_8x2_50k_kitti2015_288x960.pth`