### PR TITLE
[Fix] Fix the prefix of kitti evaluator

### DIFF
--- a/configs/_base_/datasets/kitti2012_kitti2015_320x896.py
+++ b/configs/_base_/datasets/kitti2012_kitti2015_320x896.py
@@ -92,12 +92,12 @@ test_dataloader = val_dataloader
 
 val_evaluator = [
     [
-        dict(type='EndPointError', prefix='KITTI2015_EPE'),
-        dict(type='FlowOutliers', prefix='KITTI2015_Fl')
+        dict(type='EndPointError', prefix='KITTI2015'),
+        dict(type='FlowOutliers', prefix='KITTI2015')
     ],
     [
-        dict(type='EndPointError', prefix='KITTI2012_EPE'),
-        dict(type='FlowOutliers', prefix='KITTI2012_Fl')
+        dict(type='EndPointError', prefix='KITTI2012'),
+        dict(type='FlowOutliers', prefix='KITTI2012')
     ],
 ]
 test_evaluator = val_evaluator

--- a/configs/_base_/datasets/kitti2012_kitti2015_irr_320x896.py
+++ b/configs/_base_/datasets/kitti2012_kitti2015_irr_320x896.py
@@ -92,12 +92,12 @@ test_dataloader = val_dataloader
 
 val_evaluator = [
     [
-        dict(type='EndPointError', prefix='KITTI2015_EPE'),
-        dict(type='FlowOutliers', prefix='KITTI2015_Fl')
+        dict(type='EndPointError', prefix='KITTI2015'),
+        dict(type='FlowOutliers', prefix='KITTI2015')
     ],
     [
-        dict(type='EndPointError', prefix='KITTI2012_EPE'),
-        dict(type='FlowOutliers', prefix='KITTI2012_Fl')
+        dict(type='EndPointError', prefix='KITTI2012'),
+        dict(type='FlowOutliers', prefix='KITTI2012')
     ],
 ]
 test_evaluator = val_evaluator

--- a/configs/_base_/datasets/kitti2015_raft_288x960.py
+++ b/configs/_base_/datasets/kitti2015_raft_288x960.py
@@ -59,7 +59,7 @@ val_dataloader = dict(
 test_dataloader = val_dataloader
 
 val_evaluator = [
-    dict(type='EndPointError', prefix='KITTI2015_EPE'),
-    dict(type='FlowOutliers', prefix='KITTI2015_Fl')
+    dict(type='EndPointError', prefix='KITTI2015'),
+    dict(type='FlowOutliers', prefix='KITTI2015')
 ]
 test_evaluator = val_evaluator

--- a/configs/_base_/datasets/sintel_kitti_liteflownet2_320x768.py
+++ b/configs/_base_/datasets/sintel_kitti_liteflownet2_320x768.py
@@ -171,8 +171,8 @@ val_evaluator = [
     dict(type='EndPointError', prefix='clean'),
     dict(type='EndPointError', prefix='final'),
     [
-        dict(type='EndPointError', prefix='KITTI2015_EPE'),
-        dict(type='FlowOutliers', prefix='KITTI2015_Fl')
+        dict(type='EndPointError', prefix='KITTI2015'),
+        dict(type='FlowOutliers', prefix='KITTI2015')
     ]
 ]
 test_evaluator = val_evaluator


### PR DESCRIPTION
## Motivation
The original configs of KITTI evaluator are redundant. This PR aims to fix them.

## Attention
The visualization of training logs has already modified in this [PR](https://github.com/open-mmlab/mmflow/pull/208), seen in the [file](https://github.com/open-mmlab/mmflow/blob/1f6055d32a2bb2ebe7e7d3d0c1fa2739136333a6/tools/analysis_tools/analyze_logs.py).

## Modification
1. configs/\_base\_/datasets/kitti2012_kitti2015_320x896.py
2. configs/\_base\_/datasets/kitti2012_kitti2015_irr_320x896.py
3. configs/\_base\_/datasets/kitti2015_raft_288x960.py
4. configs/\_base\_/datasets/sintel_kitti_liteflownet2_320x768.py