### PR TITLE
[Fix] Fix the relative paths in tests

### DIFF
--- a/tests/test_datasets/test_transforms/test_advanced_transform.py
+++ b/tests/test_datasets/test_transforms/test_advanced_transform.py
@@ -11,12 +11,12 @@ from mmflow.datasets.transforms.advanced_transform import (RandomAffine,
                                                            transform_flow)
 from mmflow.datasets.utils import read_flow
 
-img1_ = '../data/0000000-img_0.png'
-img2_ = '../data/0000000-img_1.png'
-flow_fw_ = '../data/0000000-flow_01.flo'
-flow_bw_ = '../data/0000000-flow_10.flo'
-occ_fw_ = '../data/0000000-occ_01.png'
-occ_bw_ = '../data/0000000-occ_10.png'
+img1_ = '../../data/0000000-img_0.png'
+img2_ = '../../data/0000000-img_1.png'
+flow_fw_ = '../../data/0000000-flow_01.flo'
+flow_bw_ = '../../data/0000000-flow_10.flo'
+occ_fw_ = '../../data/0000000-occ_01.png'
+occ_bw_ = '../../data/0000000-occ_10.png'
 
 
 def test_is_valid():

--- a/tests/test_datasets/test_transforms/test_loading.py
+++ b/tests/test_datasets/test_transforms/test_loading.py
@@ -10,14 +10,14 @@ from mmflow.datasets.transforms import LoadAnnotations
 from mmflow.datasets.utils import read_flow_kitti
 from mmflow.registry import TRANSFORMS
 
-img1_ = osp.join(osp.dirname(__file__), '../data/00001_img1.ppm')
-img2_ = osp.join(osp.dirname(__file__), '../data/00001_img2.ppm')
-flow_ = osp.join(osp.dirname(__file__), '../data/00001_flow.flo')
-flow_fw = osp.join(osp.dirname(__file__), '../data/0000000-flow_01.flo')
-flow_bw = osp.join(osp.dirname(__file__), '../data/0000000-flow_10.flo')
-occ_fw = osp.join(osp.dirname(__file__), '../data/0000000-occ_01.png')
-occ_bw = osp.join(osp.dirname(__file__), '../data/0000000-occ_10.png')
-sparse_flow_fw = osp.join(osp.dirname(__file__), '../data/sparse_flow.png')
+img1_ = osp.join(osp.dirname(__file__), '../../data/00001_img1.ppm')
+img2_ = osp.join(osp.dirname(__file__), '../../data/00001_img2.ppm')
+flow_ = osp.join(osp.dirname(__file__), '../../data/00001_flow.flo')
+flow_fw = osp.join(osp.dirname(__file__), '../../data/0000000-flow_01.flo')
+flow_bw = osp.join(osp.dirname(__file__), '../../data/0000000-flow_10.flo')
+occ_fw = osp.join(osp.dirname(__file__), '../../data/0000000-occ_01.png')
+occ_bw = osp.join(osp.dirname(__file__), '../../data/0000000-occ_10.png')
+sparse_flow_fw = osp.join(osp.dirname(__file__), '../../data/sparse_flow.png')
 
 
 class TestLoading:

--- a/tests/test_datasets/test_transforms/test_transforms.py
+++ b/tests/test_datasets/test_transforms/test_transforms.py
@@ -11,12 +11,12 @@ from mmflow.datasets import Compose
 from mmflow.datasets.utils import read_flow
 from mmflow.registry import TRANSFORMS
 
-img1_ = '../data/0000000-img_0.png'
-img2_ = '../data/0000000-img_1.png'
-flow_fw_ = '../data/0000000-flow_01.flo'
-flow_bw_ = '../data/0000000-flow_10.flo'
-occ_fw_ = '../data/0000000-occ_01.png'
-occ_bw_ = '../data/0000000-occ_10.png'
+img1_ = '../../data/0000000-img_0.png'
+img2_ = '../../data/0000000-img_1.png'
+flow_fw_ = '../../data/0000000-flow_01.flo'
+flow_bw_ = '../../data/0000000-flow_10.flo'
+occ_fw_ = '../../data/0000000-occ_01.png'
+occ_bw_ = '../../data/0000000-occ_10.png'
 
 
 def make_testdata_for_train():


### PR DESCRIPTION
## Motivation
The changes of file structures result in the change of relative path, leading to the failure of UT.

## Modification
1. tests/test_datasets/test_transforms/test_advanced_transform.py
2. tests/test_datasets/test_transforms/test_loading.py
3. tests/test_datasets/test_transforms/test_transforms.py