### PR TITLE
[Fix] Delete phase info in metainfo

### DIFF
--- a/mmflow/datasets/chairssdhom.py
+++ b/mmflow/datasets/chairssdhom.py
@@ -57,14 +57,6 @@ class ChairsSDHom(MME_BaseDataset):
                  test_mode: bool = False,
                  lazy_init: bool = False,
                  max_refetch: int = 1000) -> None:
-        if metainfo is None:
-            metainfo = dict(subset='test') if test_mode else dict(
-                subset='train')
-        else:
-            if test_mode:
-                metainfo.update(dict(subset='test'))
-            else:
-                metainfo.update(dict(subset='train'))
         super().__init__(ann_file, metainfo, data_root, data_prefix,
                          filter_cfg, indices, serialize_data, pipeline,
                          test_mode, lazy_init, max_refetch)

--- a/mmflow/datasets/flyingchairs.py
+++ b/mmflow/datasets/flyingchairs.py
@@ -59,14 +59,6 @@ class FlyingChairs(MME_BaseDataset):
                  lazy_init: bool = False,
                  max_refetch: int = 1000) -> None:
         self.split = split_file
-        if metainfo is None:
-            metainfo = dict(subset='test') if test_mode else dict(
-                subset='train')
-        else:
-            if test_mode:
-                metainfo.update(dict(subset='test'))
-            else:
-                metainfo.update(dict(subset='train'))
         super().__init__(ann_file, metainfo, data_root, data_prefix,
                          filter_cfg, indices, serialize_data, pipeline,
                          test_mode, lazy_init, max_refetch)

--- a/mmflow/datasets/flyingchairsocc.py
+++ b/mmflow/datasets/flyingchairsocc.py
@@ -90,14 +90,6 @@ class FlyingChairsOcc(MME_BaseDataset):
                  test_mode: bool = False,
                  lazy_init: bool = False,
                  max_refetch: int = 1000):
-        if metainfo is None:
-            metainfo = dict(subset='test') if test_mode else dict(
-                subset='train')
-        else:
-            if test_mode:
-                metainfo.update(dict(subset='test'))
-            else:
-                metainfo.update(dict(subset='train'))
         if split_file is not None:
             self.split = np.loadtxt(split_file, dtype=np.int32).tolist()
         else:

--- a/mmflow/datasets/flyingthings3d.py
+++ b/mmflow/datasets/flyingthings3d.py
@@ -82,7 +82,6 @@ class FlyingThings3D(MME_BaseDataset):
         f'but got {pass_style}'
         self.pass_style = pass_style
         self.double = double
-        metainfo = dict(subset='test') if test_mode else dict(subset='train')
 
         super().__init__(ann_file, metainfo, data_root, data_prefix,
                          filter_cfg, indices, serialize_data, pipeline,

--- a/mmflow/datasets/flyingthings3d_subset.py
+++ b/mmflow/datasets/flyingthings3d_subset.py
@@ -124,7 +124,6 @@ class FlyingThings3DSubset(MME_BaseDataset):
                 'left', 'right'
             ), f'`scene` expected to be \'left\' or \'right\' but got {scene}'
         self.scene = scene
-        metainfo = dict(subset='test') if test_mode else dict(subset='train')
 
         super().__init__(ann_file, metainfo, data_root, data_prefix,
                          filter_cfg, indices, serialize_data, pipeline,

--- a/tests/test_datasets/test_datasets.py
+++ b/tests/test_datasets/test_datasets.py
@@ -23,8 +23,6 @@ class TestFlyingChiars:
 
         assert len(train_dataset) == 4
         assert len(test_dataset) == 1
-        assert train_dataset.metainfo['subset'] == 'train'
-        assert test_dataset.metainfo['subset'] == 'test'
 
         split = np.loadtxt(
             osp.join(self.data_root, 'FlyingChairs_train_val.txt'),
@@ -104,8 +102,6 @@ class TestFlyingThings3D:
             train_dataset, test_dataset = self._load_annotation_file()
         else:
             train_dataset, test_dataset = self._load_path_parsing()
-        assert train_dataset.metainfo['subset'] == 'train'
-        assert test_dataset.metainfo['subset'] == 'test'
 
         multiple_param = 2 if double else 1
         for dataset in (train_dataset, test_dataset):
@@ -186,9 +182,6 @@ class TestFlyingThings3DSubset:
             train_dataset, test_dataset = self._load_annotation_file()
         else:
             train_dataset, test_dataset = self._load_path_parsing()
-
-        assert train_dataset.metainfo['subset'] == 'train'
-        assert test_dataset.metainfo['subset'] == 'test'
 
         for dataset in (train_dataset, test_dataset):
             if self.scene is None:
@@ -388,8 +381,6 @@ class TestFlyingChairsOcc:
 
         assert len(train_dataset) == 1
         assert len(test_dataset) == 1
-        assert train_dataset.metainfo['subset'] == 'train'
-        assert test_dataset.metainfo['subset'] == 'test'
 
         split = np.loadtxt(
             osp.join(self.data_root, 'FlyingChairsOcc_train_val.txt'),
@@ -507,8 +498,6 @@ class TestChairsSDHom:
 
         assert len(train_dataset) == 1
         assert len(test_dataset) == 1
-        assert train_dataset.metainfo['subset'] == 'train'
-        assert test_dataset.metainfo['subset'] == 'test'
 
         # Test if the filenames of img1, img2 and flow are the same.
         for dataset in [train_dataset, test_dataset]:


### PR DESCRIPTION
## Motivation
The differences in metainfo might lead to failure when building  `ConcatDataset`. Thus, this PR aims to delete phase related information in metainfo.

## Modification
Delete the `subset` field in mmflow/datasets and tests/test_datasets