### PR TITLE
[Fix] Fix bugs in inference and configs

### DIFF
--- a/configs/_base_/datasets/sintel_final_irr_with_occ_384x768.py
+++ b/configs/_base_/datasets/sintel_final_irr_with_occ_384x768.py
@@ -1,5 +1,3 @@
-img_norm_cfg = dict(mean=[0., 0., 0.], std=[255., 255., 255.], to_rgb=False)
-
 crop_size = (384, 768)
 
 global_transform = dict(
@@ -87,3 +85,10 @@ val_dataloader = [
         persistent_workers=True,
         dataset=sintel_final_test)
 ]
+
+test_dataloader = val_dataloader
+val_evaluator = [
+    dict(type='EndPointError', prefix='clean'),
+    dict(type='EndPointError', prefix='final')
+]
+test_evaluator = val_evaluator

--- a/configs/irr/irrpwc_ft_4x1_300k_kitti_320x896.py
+++ b/configs/irr/irrpwc_ft_4x1_300k_kitti_320x896.py
@@ -6,6 +6,13 @@ _base_ = [
 
 model = dict(
     type='IRRPWC',
+    data_preprocessor=dict(
+        type='FlowDataPreprocessor',
+        mean=[0., 0., 0.],
+        std=[255., 255., 255.],
+        bgr_to_rgb=False,
+        sigma_range=(0, 0.04),
+        clamp_range=(0., 1.)),
     encoder=dict(
         type='PWCNetEncoder',
         in_channels=3,

--- a/configs/irr/irrpwc_ft_4x1_300k_sintel_384x768.py
+++ b/configs/irr/irrpwc_ft_4x1_300k_sintel_384x768.py
@@ -6,6 +6,13 @@ _base_ = [
 
 model = dict(
     type='IRRPWC',
+    data_preprocessor=dict(
+        type='FlowDataPreprocessor',
+        mean=[0., 0., 0.],
+        std=[255., 255., 255.],
+        bgr_to_rgb=False,
+        sigma_range=(0, 0.04),
+        clamp_range=(0., 1.)),
     encoder=dict(
         type='PWCNetEncoder',
         in_channels=3,

--- a/configs/irr/irrpwc_ft_4x1_300k_sintel_final_384x768.py
+++ b/configs/irr/irrpwc_ft_4x1_300k_sintel_final_384x768.py
@@ -6,6 +6,13 @@ _base_ = [
 
 model = dict(
     type='IRRPWC',
+    data_preprocessor=dict(
+        type='FlowDataPreprocessor',
+        mean=[0., 0., 0.],
+        std=[255., 255., 255.],
+        bgr_to_rgb=False,
+        sigma_range=(0, 0.04),
+        clamp_range=(0., 1.)),
     encoder=dict(
         type='PWCNetEncoder',
         in_channels=3,

--- a/mmflow/apis/inference.py
+++ b/mmflow/apis/inference.py
@@ -75,7 +75,10 @@ def inference_model(model: torch.nn.Module, img1s: Union[str, np.ndarray],
         img2s = [img2s]
 
     cfg = model.cfg
-    cfg = copy.deepcopy(cfg.test_dataloader.dataset)
+    if isinstance(cfg.test_dataloader, list):
+        cfg = copy.deepcopy(cfg.test_dataloader[0].dataset)
+    else:
+        cfg = copy.deepcopy(cfg.test_dataloader.dataset)
 
     if isinstance(img1s[0], np.ndarray):
         cfg.pipeline[0].type = 'LoadImageFromWebcam'


### PR DESCRIPTION
## Motivation
The updated config might cause conflicts during inference. Plus, the configs of irr lack of `data_preprocessor`.

## Modification
1. configs/\_base\_/datasets/sintel_final_irr_with_occ_384x768.py
2. configs/irr/irrpwc_ft_4x1_300k_kitti_320x896.py
3. configs/irr/irrpwc_ft_4x1_300k_sintel_384x768.py
4. configs/irr/irrpwc_ft_4x1_300k_sintel_final_384x768.py
5. mmflow/apis/inference.py