### PR TITLE
[Fix] Remove the modules from mmcv.utils and mmcv.runner

### DIFF
--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -2,7 +2,7 @@
 import os.path as osp
 from argparse import ArgumentParser
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 
 from mmflow.apis import inference_model, init_model
 from mmflow.datasets import visualize_flow, write_flow
@@ -39,7 +39,7 @@ def main(args):
     # get prediction from result and convert to np
     pred_flow_fw = result[0].pred_flow_fw.data.permute(1, 2, 0).cpu().numpy()
     # save the results
-    mmcv.mkdir_or_exist(args.out_dir)
+    mkdir_or_exist(args.out_dir)
     visualize_flow(pred_flow_fw,
                    osp.join(args.out_dir, f'{args.out_prefix}.png'))
     write_flow(pred_flow_fw, osp.join(args.out_dir, f'{args.out_prefix}.flo'))

--- a/mmflow/apis/inference.py
+++ b/mmflow/apis/inference.py
@@ -22,7 +22,7 @@ def init_model(config: Union[str, Config],
     """Initialize a flow estimator from config file.
 
     Args:
-        config (str or :obj:`mmcv.Config`): Config file path or the config
+        config (str or :obj:`mmengine.Config`): Config file path or the config
             object.
         checkpoint (str, optional): Checkpoint path. If left as None, the model
             will not load any weights. Default to: None.

--- a/mmflow/datasets/__init__.py
+++ b/mmflow/datasets/__init__.py
@@ -13,8 +13,7 @@ from .sintel import Sintel
 from .transforms import (ColorJitter, Compose, Erase, GaussianNoise, InputPad,
                          InputResize, Normalize, PackFlowInputs,
                          PhotoMetricDistortion, RandomAffine, RandomCrop,
-                         RandomFlip, Rerange, SpacialTransform,
-                         TestFormatBundle, Validation)
+                         RandomFlip, Rerange, SpacialTransform, Validation)
 from .utils import (read_flow, read_flow_kitti, render_color_wheel,
                     visualize_flow, write_flow, write_flow_kitti)
 
@@ -26,5 +25,5 @@ __all__ = [
     'InputResize', 'write_flow_kitti', 'read_flow_kitti', 'GaussianNoise',
     'Compose', 'InputPad', 'FlyingThings3DSubset', 'FlyingThings3D', 'Sintel',
     'KITTI2012', 'KITTI2015', 'render_color_wheel', 'PackFlowInputs',
-    'TestFormatBundle', 'FlyingChairsOcc', 'HD1K', 'ChairsSDHom'
+    'FlyingChairsOcc', 'HD1K', 'ChairsSDHom'
 ]

--- a/mmflow/datasets/builder.py
+++ b/mmflow/datasets/builder.py
@@ -2,7 +2,7 @@
 import platform
 from typing import Optional
 
-import mmcv
+from mmengine.config import Config
 from torch.utils.data import Dataset
 
 from mmflow.registry import DATASETS
@@ -17,12 +17,11 @@ if platform.system() != 'Windows':
     resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 
-def build_dataset(cfg: mmcv.Config,
-                  default_args: Optional[dict] = None) -> Dataset:
+def build_dataset(cfg: Config, default_args: Optional[dict] = None) -> Dataset:
     """Build Pytorch dataset.
 
     Args:
-        cfg (mmcv.Config): Config dict of dataset. It should at
+        cfg (mmengine.Config): Config dict of dataset. It should at
             least contain the key "type".
         default_args (dict, optional): Default initialization arguments.
 

--- a/mmflow/datasets/transforms/__init__.py
+++ b/mmflow/datasets/transforms/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .advanced_transform import RandomAffine
 from .compose import Compose
-from .formatting import PackFlowInputs, TestFormatBundle
+from .formatting import PackFlowInputs
 from .loading import LoadAnnotations
 from .transforms import (ColorJitter, Erase, GaussianNoise, InputPad,
                          InputResize, Normalize, PhotoMetricDistortion,
@@ -12,5 +12,5 @@ __all__ = [
     'Compose', 'LoadAnnotations', 'SpacialTransform', 'Validation', 'Erase',
     'InputResize', 'InputPad', 'RandomFlip', 'Normalize', 'Rerange',
     'RandomCrop', 'ColorJitter', 'PhotoMetricDistortion', 'GaussianNoise',
-    'RandomAffine', 'TestFormatBundle', 'PackFlowInputs'
+    'RandomAffine', 'PackFlowInputs'
 ]

--- a/mmflow/datasets/utils/utils.py
+++ b/mmflow/datasets/utils/utils.py
@@ -2,7 +2,7 @@
 import os.path as osp
 from typing import Optional, Sequence, Union
 
-import mmcv
+from mmengine.utils import scandir
 
 
 def get_data_filename(
@@ -34,7 +34,7 @@ def get_data_filename(
 
     files = []
     for data_dir in data_dirs:
-        for f in mmcv.scandir(data_dir, suffix=suffix):
+        for f in scandir(data_dir, suffix=suffix):
             if f not in exclude:
                 files.append(osp.join(data_dir, f))
     files.sort()

--- a/mmflow/models/decoders/base_decoder.py
+++ b/mmflow/models/decoders/base_decoder.py
@@ -3,8 +3,8 @@ from abc import abstractmethod
 from typing import Dict, List, Optional, Sequence, Union
 
 import torch.nn.functional as F
-from mmengine.data import PixelData
 from mmengine.model import BaseModule
+from mmengine.structures import PixelData
 from torch import Tensor
 
 from mmflow.structures import FlowDataSample

--- a/mmflow/models/decoders/flownet_decoder.py
+++ b/mmflow/models/decoders/flownet_decoder.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Sequence, Tuple
 
 import torch
 import torch.nn as nn
-from mmcv.cnn import build_norm_layer
+from mmcv.cnn import build_activation_layer, build_norm_layer
 from mmengine.model import BaseModule
 from torch import Tensor
 
@@ -62,7 +62,7 @@ class DeconvModule(BaseModule):
             deconvs.append(build_norm_layer(norm_cfg, out_channels))
 
         if act_cfg is not None:
-            deconvs.append(MODELS.build(act_cfg))
+            deconvs.append(build_activation_layer(act_cfg))
 
         self.deconvs = nn.Sequential(*deconvs)
 

--- a/mmflow/models/decoders/flownet_decoder.py
+++ b/mmflow/models/decoders/flownet_decoder.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional, Sequence, Tuple
 
 import torch
 import torch.nn as nn
-from mmcv.cnn import build_activation_layer, build_norm_layer
+from mmcv.cnn import build_norm_layer
 from mmengine.model import BaseModule
 from torch import Tensor
 
@@ -62,7 +62,7 @@ class DeconvModule(BaseModule):
             deconvs.append(build_norm_layer(norm_cfg, out_channels))
 
         if act_cfg is not None:
-            deconvs.append(build_activation_layer(act_cfg))
+            deconvs.append(MODELS.build(act_cfg))
 
         self.deconvs = nn.Sequential(*deconvs)
 

--- a/mmflow/models/decoders/liteflownet_decoder.py
+++ b/mmflow/models/decoders/liteflownet_decoder.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Sequence, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from mmcv.cnn.bricks.conv_module import ConvModule
+from mmcv.cnn import ConvModule
 from mmengine.model import BaseModule
 from torch import Tensor
 

--- a/mmflow/models/decoders/maskflownet_decoder.py
+++ b/mmflow/models/decoders/maskflownet_decoder.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from mmcv.cnn import build_activation_layer
 from mmcv.ops import DeformConv2d
 from mmengine.model import BaseModule
 from torch import Tensor
@@ -57,7 +58,7 @@ class BasicDeformWarpBlock(BaseModule):
         super().__init__(init_cfg)
         self.channels = channels
         self.deconv = DeformConv2d(channels, channels, 3, padding=1)
-        self.act = MODELS.build(act_cfg)
+        self.act = build_activation_layer(act_cfg)
         self.with_deform_bias = with_deform_bias
         if self.with_deform_bias:
             self.deconv_bias = nn.Parameter(torch.zeros(channels, 1, 1))
@@ -107,7 +108,7 @@ class DeformWarpBlock(BaseModule):
         self.channels = channels
         self.deconv = DeformConv2d(channels, channels, 3, padding=1)
         self.tradeoff_conv = nn.Conv2d(up_channels, channels, 3, padding=1)
-        self.act = MODELS.build(act_cfg)
+        self.act = build_activation_layer(act_cfg)
         self.with_deform_bias = with_deform_bias
         if self.with_deform_bias:
             self.deconv_bias = nn.Parameter(torch.zeros(channels, 1, 1))
@@ -264,7 +265,7 @@ class MaskModule(PWCModule):
                     out_channels=self.up_channels,
                     kernel_size=4,
                     stride=2,
-                    padding=1), MODELS.build(self.act_cfg))
+                    padding=1), build_activation_layer(self.act_cfg))
 
     def forward(
         self, x: Tensor, upflow: Tensor

--- a/mmflow/models/decoders/maskflownet_decoder.py
+++ b/mmflow/models/decoders/maskflownet_decoder.py
@@ -4,7 +4,6 @@ from typing import Dict, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from mmcv.cnn.bricks.activation import build_activation_layer
 from mmcv.ops import DeformConv2d
 from mmengine.model import BaseModule
 from torch import Tensor
@@ -58,7 +57,7 @@ class BasicDeformWarpBlock(BaseModule):
         super().__init__(init_cfg)
         self.channels = channels
         self.deconv = DeformConv2d(channels, channels, 3, padding=1)
-        self.act = build_activation_layer(act_cfg)
+        self.act = MODELS.build(act_cfg)
         self.with_deform_bias = with_deform_bias
         if self.with_deform_bias:
             self.deconv_bias = nn.Parameter(torch.zeros(channels, 1, 1))
@@ -108,7 +107,7 @@ class DeformWarpBlock(BaseModule):
         self.channels = channels
         self.deconv = DeformConv2d(channels, channels, 3, padding=1)
         self.tradeoff_conv = nn.Conv2d(up_channels, channels, 3, padding=1)
-        self.act = build_activation_layer(act_cfg)
+        self.act = MODELS.build(act_cfg)
         self.with_deform_bias = with_deform_bias
         if self.with_deform_bias:
             self.deconv_bias = nn.Parameter(torch.zeros(channels, 1, 1))
@@ -265,7 +264,7 @@ class MaskModule(PWCModule):
                     out_channels=self.up_channels,
                     kernel_size=4,
                     stride=2,
-                    padding=1), build_activation_layer(self.act_cfg))
+                    padding=1), MODELS.build(self.act_cfg))
 
     def forward(
         self, x: Tensor, upflow: Tensor

--- a/mmflow/models/encoders/flownet_encoder.py
+++ b/mmflow/models/encoders/flownet_encoder.py
@@ -2,7 +2,7 @@
 from typing import Dict, Optional, Sequence, Union
 
 import torch
-from mmcv.cnn.bricks.conv_module import ConvModule
+from mmcv.cnn import ConvModule
 
 from mmflow.registry import MODELS
 from ..utils import CorrBlock

--- a/mmflow/models/flow_estimators/flownet.py
+++ b/mmflow/models/flow_estimators/flownet.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Tuple
 
-from mmcv.utils import Config
+from mmengine.config import Config
 from torch import Tensor
 
 from mmflow.registry import MODELS

--- a/mmflow/models/utils/correlation_block.py
+++ b/mmflow/models/utils/correlation_block.py
@@ -2,11 +2,11 @@
 from math import sqrt
 
 import torch
+from mmcv.cnn import build_activation_layer
 from mmengine.model import BaseModule
 from mmengine.runner import autocast
 
 from mmflow.models import build_operators
-from mmflow.registry import MODELS
 
 
 class CorrBlock(BaseModule):
@@ -37,7 +37,7 @@ class CorrBlock(BaseModule):
             f'but got {scale_mode}')
 
         corr = build_operators(corr_cfg)
-        act = MODELS.build(act_cfg)
+        act = build_activation_layer(act_cfg)
         self.scaled = scaled
         self.scale_mode = scale_mode
 

--- a/mmflow/models/utils/correlation_block.py
+++ b/mmflow/models/utils/correlation_block.py
@@ -2,11 +2,11 @@
 from math import sqrt
 
 import torch
-from mmcv.cnn import build_activation_layer
 from mmengine.model import BaseModule
 from mmengine.runner import autocast
 
 from mmflow.models import build_operators
+from mmflow.registry import MODELS
 
 
 class CorrBlock(BaseModule):
@@ -37,7 +37,7 @@ class CorrBlock(BaseModule):
             f'but got {scale_mode}')
 
         corr = build_operators(corr_cfg)
-        act = build_activation_layer(act_cfg)
+        act = MODELS.build(act_cfg)
         self.scaled = scaled
         self.scale_mode = scale_mode
 

--- a/mmflow/models/utils/res_layer.py
+++ b/mmflow/models/utils/res_layer.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch.nn as nn
 import torch.utils.checkpoint as cp
-from mmcv.cnn import build_conv_layer, build_norm_layer, build_plugin_layer
+from mmcv.cnn import (build_activation_layer, build_conv_layer,
+                      build_norm_layer, build_plugin_layer)
 from mmengine.model import BaseModule
-
-from mmflow.registry import MODELS
 
 
 class BasicBlock(BaseModule):
@@ -46,7 +45,7 @@ class BasicBlock(BaseModule):
             conv_cfg, planes, planes, 3, padding=1, bias=True)
         self.add_module(self.norm2_name, norm2)
 
-        self.relu = MODELS.build(act_cfg)
+        self.relu = build_activation_layer(act_cfg)
         self.downsample = downsample
         self.stride = stride
         self.dilation = dilation

--- a/mmflow/models/utils/res_layer.py
+++ b/mmflow/models/utils/res_layer.py
@@ -1,9 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch.nn as nn
 import torch.utils.checkpoint as cp
-from mmcv.cnn import (build_activation_layer, build_conv_layer,
-                      build_norm_layer, build_plugin_layer)
+from mmcv.cnn import build_conv_layer, build_norm_layer, build_plugin_layer
 from mmengine.model import BaseModule
+
+from mmflow.registry import MODELS
 
 
 class BasicBlock(BaseModule):
@@ -45,7 +46,7 @@ class BasicBlock(BaseModule):
             conv_cfg, planes, planes, 3, padding=1, bias=True)
         self.add_module(self.norm2_name, norm2)
 
-        self.relu = build_activation_layer(act_cfg)
+        self.relu = MODELS.build(act_cfg)
         self.downsample = downsample
         self.stride = stride
         self.dilation = dilation

--- a/mmflow/structures/flow_data_sample.py
+++ b/mmflow/structures/flow_data_sample.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-from mmengine.data import BaseDataElement, PixelData
+from mmengine.structures import BaseDataElement, PixelData
 
 
 class FlowDataSample(BaseDataElement):
@@ -35,7 +35,7 @@ class FlowDataSample(BaseDataElement):
     Examples:
         >>> import torch
         >>> import numpy as np
-        >>> from mmengine.data import PixelData
+        >>> from mmengine.structures import PixelData
         >>> from mmflow.structures import FlowDataSample
 
         >>> data_sample = FlowDataSample()

--- a/mmflow/utils/misc.py
+++ b/mmflow/utils/misc.py
@@ -2,7 +2,7 @@
 import numpy as np
 import torch
 import torch.distributed as dist
-from mmcv.runner import get_dist_info
+from mmengine.dist import get_dist_info
 
 
 def sync_random_seed(seed=None, device='cuda'):

--- a/mmflow/visualization/local_visualizer.py
+++ b/mmflow/visualization/local_visualizer.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import mmcv
 import numpy as np
-from mmengine import Visualizer
+from mmengine.visualization import Visualizer
 
 from mmflow.registry import VISUALIZERS
 from mmflow.structures import FlowDataSample

--- a/tests/test_datasets/test_transforms/test_formatting.py
+++ b/tests/test_datasets/test_transforms/test_formatting.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
 
 from mmflow.datasets.transforms import PackFlowInputs
 from mmflow.structures import FlowDataSample

--- a/tests/test_engine/test_hooks/test_visualization_hook.py
+++ b/tests/test_engine/test_hooks/test_visualization_hook.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
 
 from mmflow.datasets import read_flow
 from mmflow.engine.hooks import FlowVisualizationHook

--- a/tests/test_models/test_decoders/test_flownet_decoder.py
+++ b/tests/test_models/test_decoders/test_flownet_decoder.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import pytest
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 
 from mmflow.models.decoders.flownet_decoder import (BasicBlock, DeconvModule,
                                                     FlowNetCDecoder,
@@ -151,7 +151,7 @@ def test_flownets_decoder(in_channels, out_channels, inter_channels):
 
     # test predict forward
     out = model.predict(feat, data_samples=data_samples)
-    assert isinstance(out, list) and mmcv.is_list_of(out, FlowDataSample)
+    assert isinstance(out, list) and is_list_of(out, FlowDataSample)
     assert out[0].pred_flow_fw.shape == (64, 64)
 
 
@@ -193,5 +193,5 @@ def test_flownetc_decoder():
 
     # test predict forward
     out = model.predict(feat1, corr_feat, data_samples=data_samples)
-    assert isinstance(out, list) and mmcv.is_list_of(out, FlowDataSample)
+    assert isinstance(out, list) and is_list_of(out, FlowDataSample)
     assert out[0].pred_flow_fw.shape == (64, 64)

--- a/tests/test_models/test_decoders/test_gma_decoder.py
+++ b/tests/test_models/test_decoders/test_gma_decoder.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import pytest
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 
 from mmflow.models.decoders.gma_decoder import (Aggregate, Attention,
                                                 GMADecoder, RelPosEmb)
@@ -139,4 +139,4 @@ def test_gmadecoder(max_pos_size, position_only):
         out = model.predict(
             feat1, feat2, flow, h_feat, cxt_feat, data_samples=data_samples)
         assert out[0].pred_flow_fw.shape == (64, 64)
-        assert isinstance(out, list) and mmcv.is_list_of(out, FlowDataSample)
+        assert isinstance(out, list) and is_list_of(out, FlowDataSample)

--- a/tests/test_models/test_decoders/test_irrpwc_decoder.py
+++ b/tests/test_models/test_decoders/test_irrpwc_decoder.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import pytest
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 
 from mmflow.models.decoders.irrpwc_decoder import (IRRCorrBlock,
                                                    IRRFlowDecoder,
@@ -236,7 +236,7 @@ def test_irr_pwc_decoder():
 
     # test predict forward
     flow_result = model.predict(feat1, feat2, data_samples=data_samples)
-    assert isinstance(flow_result, list) and mmcv.is_list_of(
+    assert isinstance(flow_result, list) and is_list_of(
         flow_result, FlowDataSample)
     assert flow_result[0].pred_flow_fw.shape == (h, w)
     assert flow_result[0].pred_flow_bw.shape == (h, w)

--- a/tests/test_models/test_decoders/test_liteflownet_decoder.py
+++ b/tests/test_models/test_decoders/test_liteflownet_decoder.py
@@ -1,9 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import pytest
 import torch
 import torch.nn as nn
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 
 from mmflow.models.decoders.liteflownet_decoder import (BasicBlock,
                                                         MatchingBlock, NetE,
@@ -205,7 +205,7 @@ def test_nete(extra_training_loss, regularized_flow):
 
     # test predict forward
     out = nete.predict(img1, img2, feat1, feat2, data_samples=data_samples)
-    assert isinstance(out, list) and mmcv.is_list_of(out, FlowDataSample)
+    assert isinstance(out, list) and is_list_of(out, FlowDataSample)
     assert out[0].pred_flow_fw.shape == (16, 16)
 
     # test forward

--- a/tests/test_models/test_decoders/test_maskflownets_decoder.py
+++ b/tests/test_models/test_decoders/test_maskflownets_decoder.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import pytest
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 
 from mmflow.models.decoders.maskflownet_decoder import (BasicDeformWarpBlock,
                                                         DeformWarpBlock,
@@ -150,7 +150,7 @@ def test_maskflownets_decoder():
 
     # test predict forward
     out = model.predict(feat1, feat2, data_samples=data_samples)
-    assert isinstance(out, list) and mmcv.is_list_of(out, FlowDataSample)
+    assert isinstance(out, list) and is_list_of(out, FlowDataSample)
     assert out[0].pred_flow_fw.shape == (16, 16)
 
     # test forward function

--- a/tests/test_models/test_decoders/test_pwcnet_decoder.py
+++ b/tests/test_models/test_decoders/test_pwcnet_decoder.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import pytest
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 
 from mmflow.models.decoders.pwcnet_decoder import PWCModule, PWCNetDecoder
 from mmflow.structures import FlowDataSample
@@ -82,7 +82,7 @@ def test_pwcnet_decoder():
     assert float(loss['loss_flow']) > 0
 
     out = model.predict(feat1, feat2, data_samples=data_samples)
-    assert isinstance(out, list) and mmcv.is_list_of(out, FlowDataSample)
+    assert isinstance(out, list) and is_list_of(out, FlowDataSample)
     assert out[0].pred_flow_fw.shape == (32, 32)
 
     out = model(feat1, feat2)

--- a/tests/test_models/test_decoders/test_raft_decoder.py
+++ b/tests/test_models/test_decoders/test_raft_decoder.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import pytest
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 
 from mmflow.models.decoders.raft_decoder import (ConvGRU, CorrelationPyramid,
                                                  MotionEncoder, RAFTDecoder,
@@ -134,4 +134,4 @@ def test_raft_decoder():
     out = model.predict(
         feat1, feat2, flow, h_feat, cxt_feat, data_samples=data_samples)
     assert out[0].pred_flow_fw.shape == (64, 64)
-    assert isinstance(out, list) and mmcv.is_list_of(out, FlowDataSample)
+    assert isinstance(out, list) and is_list_of(out, FlowDataSample)

--- a/tests/test_models/test_flow_estimators.py
+++ b/tests/test_models/test_flow_estimators.py
@@ -3,8 +3,9 @@ import os.path as osp
 
 import pytest
 import torch
-from mmcv.utils import Config, is_list_of
-from mmengine.data import PixelData
+from mmengine.config import Config
+from mmengine.structures import PixelData
+from mmengine.utils import is_list_of
 from torch import Tensor
 
 from mmflow.models import MaskFlowNetS, build_flow_estimator

--- a/tests/test_structures/test_flow_data_sample.py
+++ b/tests/test_structures/test_flow_data_sample.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
 
 from mmflow.structures import FlowDataSample
 

--- a/tests/test_visualization/test_local_visualizer.py
+++ b/tests/test_visualization/test_local_visualizer.py
@@ -2,7 +2,7 @@
 from unittest import TestCase
 
 import torch
-from mmengine.data import PixelData
+from mmengine.structures import PixelData
 
 from mmflow.structures import FlowDataSample
 from mmflow.visualization import FlowLocalVisualizer

--- a/tools/dataset_converters/prepare_chairssdhom.py
+++ b/tools/dataset_converters/prepare_chairssdhom.py
@@ -3,7 +3,7 @@ import argparse
 import json
 import os.path as osp
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 from utils import get_data_filename
 
 
@@ -55,7 +55,7 @@ def main():
                 img2_path=img2_filenames[i],
                 flow_fw_path=flow_filenames[i])
             data_list.append(data_info)
-        mmcv.mkdir_or_exist(args.save_dir)
+        mkdir_or_exist(args.save_dir)
         with open(osp.join(args.save_dir, f'{subset_dir}.json'),
                   'w') as jsonfile:
             json.dump({

--- a/tools/dataset_converters/prepare_flyingchairs.py
+++ b/tools/dataset_converters/prepare_flyingchairs.py
@@ -3,8 +3,8 @@ import argparse
 import json
 import os.path as osp
 
-import mmcv
 import numpy as np
+from mmengine.utils import mkdir_or_exist, scandir
 
 
 def parse_args():
@@ -46,9 +46,9 @@ def main():
     img2_suffix = '_img2.ppm'
     flow_suffix = '_flow.flo'
 
-    img1_filenames = [f for f in mmcv.scandir(img1_dir, suffix=img1_suffix)]
-    img2_filenames = [f for f in mmcv.scandir(img2_dir, suffix=img2_suffix)]
-    flow_filenames = [f for f in mmcv.scandir(flow_dir, suffix=flow_suffix)]
+    img1_filenames = [f for f in scandir(img1_dir, suffix=img1_suffix)]
+    img2_filenames = [f for f in scandir(img2_dir, suffix=img2_suffix)]
+    flow_filenames = [f for f in scandir(flow_dir, suffix=flow_suffix)]
     img1_filenames.sort()
     img2_filenames.sort()
     flow_filenames.sort()
@@ -67,7 +67,7 @@ def main():
             train_list.append(data_info)
         else:
             test_list.append(data_info)
-    mmcv.mkdir_or_exist(args.save_dir)
+    mkdir_or_exist(args.save_dir)
     with open(osp.join(args.save_dir, 'train.json'), 'w') as jsonfile:
         json.dump({'data_list': train_list, 'metainfo': {}}, jsonfile)
 

--- a/tools/dataset_converters/prepare_flyingchairsocc.py
+++ b/tools/dataset_converters/prepare_flyingchairsocc.py
@@ -3,8 +3,8 @@ import argparse
 import json
 import os.path as osp
 
-import mmcv
 import numpy as np
+from mmengine.utils import mkdir_or_exist, scandir
 
 DATASET_SIZE = 22872
 VALIDATE_INDICES = [
@@ -102,16 +102,12 @@ def main():
     occ_fw_suffix = '_occ1.png'
     occ_bw_suffix = '_occ2.png'
 
-    img1_filenames = [f for f in mmcv.scandir(img1_dir, suffix=img1_suffix)]
-    img2_filenames = [f for f in mmcv.scandir(img2_dir, suffix=img2_suffix)]
-    flow_fw_filenames = [
-        f for f in mmcv.scandir(flow_dir, suffix=flow_fw_suffix)
-    ]
-    flow_bw_filenames = [
-        f for f in mmcv.scandir(flow_dir, suffix=flow_bw_suffix)
-    ]
-    occ_fw_filenames = [f for f in mmcv.scandir(occ_dir, suffix=occ_fw_suffix)]
-    occ_bw_filenames = [f for f in mmcv.scandir(occ_dir, suffix=occ_bw_suffix)]
+    img1_filenames = [f for f in scandir(img1_dir, suffix=img1_suffix)]
+    img2_filenames = [f for f in scandir(img2_dir, suffix=img2_suffix)]
+    flow_fw_filenames = [f for f in scandir(flow_dir, suffix=flow_fw_suffix)]
+    flow_bw_filenames = [f for f in scandir(flow_dir, suffix=flow_bw_suffix)]
+    occ_fw_filenames = [f for f in scandir(occ_dir, suffix=occ_fw_suffix)]
+    occ_bw_filenames = [f for f in scandir(occ_dir, suffix=occ_bw_suffix)]
 
     train_list = []
     test_list = []
@@ -130,7 +126,7 @@ def main():
             train_list.append(data_info)
         else:
             test_list.append(data_info)
-    mmcv.mkdir_or_exist(args.save_dir)
+    mkdir_or_exist(args.save_dir)
     with open(osp.join(args.save_dir, 'train.json'), 'w') as jsonfile:
         json.dump({'data_list': train_list, 'metainfo': {}}, jsonfile)
 

--- a/tools/dataset_converters/prepare_flyingthings3d.py
+++ b/tools/dataset_converters/prepare_flyingthings3d.py
@@ -4,7 +4,7 @@ import json
 import os.path as osp
 from glob import glob
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 from utils import get_data_filename
 
 
@@ -106,7 +106,7 @@ def main():
             data_list.append(data_info)
             data_list.append(data_info_final)
 
-        mmcv.mkdir_or_exist(args.save_dir)
+        mkdir_or_exist(args.save_dir)
         if subset_dir == 'TRAIN':
             annotation_file = osp.join(args.save_dir, 'train.json')
         else:

--- a/tools/dataset_converters/prepare_flyingthings3d_subset.py
+++ b/tools/dataset_converters/prepare_flyingthings3d_subset.py
@@ -6,7 +6,7 @@ import os.path as osp
 import re
 from typing import Sequence
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 from utils import get_data_filename
 
 # these files contain nan, so exclude them.
@@ -172,7 +172,7 @@ def main():
                     train_list.append(data_info)
                 else:
                     test_list.append(data_info)
-    mmcv.mkdir_or_exist(args.save_dir)
+    mkdir_or_exist(args.save_dir)
     with open(osp.join(args.save_dir, 'train.json'), 'w') as jsonfile:
         json.dump({'data_list': train_list, 'metainfo': {}}, jsonfile)
     with open(osp.join(args.save_dir, 'test.json'), 'w') as jsonfile:

--- a/tools/dataset_converters/prepare_hd1k.py
+++ b/tools/dataset_converters/prepare_hd1k.py
@@ -4,7 +4,7 @@ import json
 import os.path as osp
 from glob import glob
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 
 
 def parse_args():
@@ -59,7 +59,7 @@ def main():
             flow_fw_path=osp.join(flow_filenames[i]))
 
         train_list.append(data_info)
-    mmcv.mkdir_or_exist(args.save_dir)
+    mkdir_or_exist(args.save_dir)
     with open(osp.join(args.save_dir, 'train.json'), 'w') as jsonfile:
         json.dump({'metainfo': {}, 'data_list': train_list}, jsonfile)
 

--- a/tools/dataset_converters/prepare_kitti2012.py
+++ b/tools/dataset_converters/prepare_kitti2012.py
@@ -3,7 +3,7 @@ import argparse
 import json
 import os.path as osp
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 from utils import get_data_filename
 
 
@@ -50,7 +50,7 @@ def main():
             img1_path=i_img1, img2_path=i_img2, flow_fw_path=i_flow_fw)
         data_list.append(data_info)
 
-    mmcv.mkdir_or_exist(args.save_dir)
+    mkdir_or_exist(args.save_dir)
     annotation_file = osp.join(args.save_dir, 'train.json')
     with open(annotation_file, 'w') as jsonfile:
         json.dump({'data_list': data_list, 'metainfo': {}}, jsonfile)

--- a/tools/dataset_converters/prepare_kitti2015.py
+++ b/tools/dataset_converters/prepare_kitti2015.py
@@ -3,7 +3,7 @@ import argparse
 import json
 import os.path as osp
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 from utils import get_data_filename
 
 
@@ -50,7 +50,7 @@ def main():
             img1_path=i_img1, img2_path=i_img2, flow_fw_path=i_flow_fw)
         data_list.append(data_info)
 
-    mmcv.mkdir_or_exist(args.save_dir)
+    mkdir_or_exist(args.save_dir)
     annotation_file = osp.join(args.save_dir, 'train.json')
     with open(annotation_file, 'w') as jsonfile:
         json.dump({'data_list': data_list, 'metainfo': {}}, jsonfile)

--- a/tools/dataset_converters/prepare_sintel.py
+++ b/tools/dataset_converters/prepare_sintel.py
@@ -4,7 +4,7 @@ import json
 import os
 import os.path as osp
 
-import mmcv
+from mmengine.utils import mkdir_or_exist
 from utils import get_data_filename
 
 
@@ -91,7 +91,7 @@ def main():
                         invalid_path=i_invalid,
                         occ_fw_path=i_occ)
                     data_list.append(data_info)
-        mmcv.mkdir_or_exist(args.save_dir)
+        mkdir_or_exist(args.save_dir)
         if subset_dir == 'training':
             annotation_file = osp.join(args.save_dir, 'train.json')
         else:

--- a/tools/dataset_converters/utils.py
+++ b/tools/dataset_converters/utils.py
@@ -3,7 +3,7 @@
 import os.path as osp
 from typing import Optional, Sequence, Union
 
-import mmcv
+from mmengine.utils import scandir
 
 
 def get_data_filename(
@@ -33,7 +33,7 @@ def get_data_filename(
 
     files = []
     for data_dir in data_dirs:
-        for f in mmcv.scandir(data_dir, suffix=suffix):
+        for f in scandir(data_dir, suffix=suffix):
             if f not in exclude:
                 files.append(osp.join(data_dir, f))
     files.sort()

--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -2,8 +2,8 @@
 import argparse
 import os.path as osp
 
-import mmcv
-from mmcv import Config, DictAction
+from mmengine.config import Config, DictAction
+from mmengine.utils import ProgressBar
 
 from mmflow.datasets.builder import build_dataset
 from mmflow.registry import VISUALIZERS
@@ -47,7 +47,7 @@ def main():
     visualizer = VISUALIZERS.build(cfg.visualizer)
     visualizer.dataset_meta = dataset.METAINFO
 
-    progress_bar = mmcv.ProgressBar(len(dataset))
+    progress_bar = ProgressBar(len(dataset))
     for item in dataset:
         data_sample = item['data_sample']
         img1_path = item['data_sample'].metainfo['img1_path']

--- a/tools/misc/frame2video.py
+++ b/tools/misc/frame2video.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 import cv2
 import mmcv
+from mmengine.utils import scandir
 from numpy import ndarray
 
 try:
@@ -65,7 +66,7 @@ def create_frame(frame_dir: str,
     Returns:
         list[ndarray]: List of frames.
     """
-    frame_files = list(mmcv.scandir(frame_dir))
+    frame_files = list(scandir(frame_dir))
     frame_files.sort()
     frame_list = []
     for frame_file in frame_files:

--- a/tools/misc/merge_imgs_flowmaps.py
+++ b/tools/misc/merge_imgs_flowmaps.py
@@ -5,6 +5,7 @@ import os.path as osp
 import cv2
 import mmcv
 import numpy as np
+from mmengine.utils import scandir
 
 try:
     import imageio
@@ -45,8 +46,8 @@ def merge_imgs_flow(img_dir: str, flow_dir: str, out_dir: str) -> None:
         flow_dir (str): The directory of flow maps.
         out_dir (str): The directory to save the frames
     """
-    img_files = list(mmcv.scandir(img_dir))
-    flow_files = list(mmcv.scandir(flow_dir))
+    img_files = list(scandir(img_dir))
+    flow_files = list(scandir(flow_dir))
     img_files.sort()
     flow_files.sort()
     # img is longer than flow

--- a/tools/misc/print_config.py
+++ b/tools/misc/print_config.py
@@ -2,7 +2,7 @@
 import argparse
 import warnings
 
-from mmcv import Config, DictAction
+from mmengine.config import Config, DictAction
 
 
 def parse_args():
@@ -46,7 +46,7 @@ def main():
         cfg.merge_from_dict(args.cfg_options)
     # import modules from string list.
     if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
+        from mmengine.utils import import_modules_from_strings
         import_modules_from_strings(**cfg['custom_imports'])
     print(f'Config:\n{cfg.pretty_text}')
 

--- a/tools/torchserve/mmflow2torchserve.py
+++ b/tools/torchserve/mmflow2torchserve.py
@@ -3,7 +3,8 @@ from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import mmcv
+from mmengine.config import Config
+from mmengine.utils import mkdir_or_exist
 
 try:
     from model_archiver.model_packaging import package_model
@@ -42,9 +43,9 @@ def mmflow2torchserve(
             If True, if there is an existing `{model_name}.mar`
             file under `output_folder` it will be overwritten.
     """
-    mmcv.mkdir_or_exist(output_folder)
+    mkdir_or_exist(output_folder)
 
-    config = mmcv.Config.fromfile(config_file)
+    config = Config.fromfile(config_file)
 
     with TemporaryDirectory() as tmpdir:
         config.dump(f'{tmpdir}/config.py')

--- a/tools/torchserve/mmflow_handler.py
+++ b/tools/torchserve/mmflow_handler.py
@@ -5,7 +5,7 @@ import os
 import cv2
 import mmcv
 import torch
-from mmcv.cnn.utils.sync_bn import revert_sync_batchnorm
+from mmengine.model.utils import revert_sync_batchnorm
 from ts.torch_handler.base_handler import BaseHandler
 
 from mmflow.apis import inference_model, init_model


### PR DESCRIPTION
## Motivation
Remove the modules from `mmcv.utils` and `mmcv.runner`, and use `mmengine` 's corresponding modules to replace.

## Modification
The imports of `mmcv.utils` and `mmcv.runner`.

## TODO
Fix `tools/benchmark.py`