### PR TITLE
[Fix] Fix in-place operator in RAFT

### DIFF
--- a/mmflow/models/utils/res_layer.py
+++ b/mmflow/models/utils/res_layer.py
@@ -78,7 +78,7 @@ class BasicBlock(BaseModule):
             if self.downsample is not None:
                 identity = self.downsample(x)
 
-            out += identity
+            out = out + identity
 
             return out
 
@@ -288,7 +288,7 @@ class Bottleneck(BaseModule):
             if self.downsample is not None:
                 identity = self.downsample(x)
 
-            out += identity
+            out = out + identity
 
             return out
 


### PR DESCRIPTION
## Motivation
In Issue #248, there is a bug when fine-tuning RAFT, which is caused by an inappropriate in-place operator. This PR aims to fix this bug.

## Modification
`mmflow/models/utils/res_layer.py`