### PR TITLE
[Fix]The `sklearn` PyPI package is deprecated, use `scikit-learn`

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,2 @@
 scipy
-sklearn
+scikit-learn

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,2 +1,2 @@
-scipy
 scikit-learn
+scipy


### PR DESCRIPTION
as title