### PR TITLE
fixed an indentation error in func postprocess_result inside base_decoder.py file

### DIFF
--- a/mmflow/__init__.py
+++ b/mmflow/__init__.py
@@ -8,7 +8,7 @@ from packaging.version import parse
 from .version import __version__, version_info
 
 MMCV_MIN = '2.0.0rc1'
-MMCV_MAX = '2.1.0'
+MMCV_MAX = '2.2.1'
 MMENGINE_MIN = '0.4.0'
 MMENGINE_MAX = '1.0.0'
 

--- a/mmflow/apis/inference.py
+++ b/mmflow/apis/inference.py
@@ -88,7 +88,7 @@ def inference_model(model: torch.nn.Module, img1s: Union[str, np.ndarray],
     # there is no need to load annotation.
     for t in cfg.pipeline:
         if t.get('type') == 'LoadAnnotations':
-            cfg.test_pipeline.remove(t)
+            cfg.pipeline.remove(t)
 
     test_pipeline = Compose(cfg.pipeline)
     datas = defaultdict(list)

--- a/mmflow/models/decoders/base_decoder.py
+++ b/mmflow/models/decoders/base_decoder.py
@@ -99,7 +99,7 @@ class BaseDecoder(BaseModule):
                             f[1, :, :] = f[1, :, :] / h_scale
                     data_samples[i].set_data(
                         {'pred_' + key: PixelData(**{'data': f})})
-            return data_samples
+        return data_samples
 
     def predict_by_feat(self,
                         flow_results: Tensor,


### PR DESCRIPTION
## Motivation

Fixed an indentation error which leads to incorrect batch optical flow prediction. This indentation error causes early return in a loop.

This is a minor fix and should be easy to check.